### PR TITLE
Use full url for repo instead of alias

### DIFF
--- a/charts/pip-account-management/Chart.yaml
+++ b/charts/pip-account-management/Chart.yaml
@@ -8,4 +8,4 @@ maintainers:
 dependencies:
   - name: java
     version: 3.5.1
-    repository: '@hmctspublic'
+    repository: 'https://hmctspublic.azurecr.io/helm/v1/repo/'


### PR DESCRIPTION
I think the alias doesn't work on sandbox 