### PR TITLE
Pub 1071 user table

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,3 +204,39 @@ Here are some other functionalities it provides:
 
 This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details
 
+## API
+Account management exposes various endpoints that aid in managing accounts within the P&I service.
+
+`/account/add/pi` - used to add a user to the P&I user database. Takes in a header of the email of the admin issuing
+the request and a body of a list of users to add to the database following the [P&I User model](#piuser) without the
+`userId` as this is created by the service.
+
+
+
+## Models
+
+### PiUser
+
+```json
+{
+  "userId": "111111-aaaa-1111-ssss-11111111",
+  "userProvenance": "PI_AAD",
+  "provenanceUserId": "222222-vvvv-11111-ssss-11111111",
+  "email": "example@email.com",
+  "roles": "INTERNAL_ADMIN_LOCAL"
+}
+```
+
+### Roles
+an enum for the different roles available to P&I.
+
+`VERIFIED` - will be media users within P&I
+
+`INTERNAL_SUPER_ADMIN_CTSC` - super admin privileges for CTSC
+
+`INTERNAL_SUPER_ADMIN_LOCAL` - super admin privileges for local courts
+
+`INTERNAL_ADMIN_CTSC` - admin privileges for CTSC
+
+`INTERNAL_ADMIN_LOCAL` - admin privileges for local courts
+

--- a/build.gradle
+++ b/build.gradle
@@ -171,6 +171,11 @@ dependencies {
   implementation group: 'org.springframework.boot', name: 'spring-boot-starter-aop'
   implementation group: 'org.springframework.boot', name: 'spring-boot-starter-json'
   implementation group: 'org.springframework.boot', name: 'spring-boot-starter-validation'
+  implementation group: 'uk.gov.hmcts.reform', name: 'pip-data-models', version: '0.0.1'
+  implementation 'org.postgresql:postgresql'
+  implementation 'org.springframework.boot:spring-boot-starter-validation'
+  implementation 'org.springframework.boot:spring-boot-starter-jdbc'
+  implementation 'org.springframework.boot:spring-boot-starter-data-jpa:2.5.5'
 
   // Include the sdk as a dependency
   implementation 'com.microsoft.graph:microsoft-graph:5.8.0'
@@ -184,6 +189,8 @@ dependencies {
 
   testImplementation(platform('org.junit:junit-bom:5.8.1'))
   testImplementation group: 'org.springframework.boot', name: 'spring-boot-starter-test'
+
+  testImplementation "io.zonky.test:embedded-database-spring-test:2.1.1"
 
   integrationTestImplementation sourceSets.main.runtimeClasspath
   integrationTestImplementation sourceSets.test.runtimeClasspath

--- a/build.gradle
+++ b/build.gradle
@@ -171,7 +171,7 @@ dependencies {
   implementation group: 'org.springframework.boot', name: 'spring-boot-starter-aop'
   implementation group: 'org.springframework.boot', name: 'spring-boot-starter-json'
   implementation group: 'org.springframework.boot', name: 'spring-boot-starter-validation'
-  implementation group: 'uk.gov.hmcts.reform', name: 'pip-data-models', version: '0.0.1'
+  implementation group: 'com.github.hmcts', name: 'pip-data-models', version: '1.0'
   implementation 'org.postgresql:postgresql'
   implementation 'org.springframework.boot:spring-boot-starter-validation'
   implementation 'org.springframework.boot:spring-boot-starter-jdbc'

--- a/build.gradle
+++ b/build.gradle
@@ -176,6 +176,8 @@ dependencies {
   implementation 'org.springframework.boot:spring-boot-starter-validation'
   implementation 'org.springframework.boot:spring-boot-starter-jdbc'
   implementation 'org.springframework.boot:spring-boot-starter-data-jpa:2.5.5'
+  implementation group: 'org.apache.tomcat.embed', name: 'tomcat-embed-core', version: '9.0.58'
+  implementation group: 'org.apache.tomcat.embed', name: 'tomcat-embed-websocket', version: '9.0.58'
 
   // Include the sdk as a dependency
   implementation 'com.microsoft.graph:microsoft-graph:5.8.0'

--- a/charts/pip-account-management/Chart.yaml
+++ b/charts/pip-account-management/Chart.yaml
@@ -8,5 +8,5 @@ maintainers:
   - name: HMCTS PIP Team
 dependencies:
   - name: java
-    version: 3.7.0
+    version: 3.7.2
     repository: 'https://hmctspublic.azurecr.io/helm/v1/repo/'

--- a/charts/pip-account-management/values.yaml
+++ b/charts/pip-account-management/values.yaml
@@ -16,11 +16,11 @@ java:
         - name: shared-storageaccount-connection-string
           alias: CONNECTION_STRING
         - name: pip-shared-POSTGRES-DATABASE
-            alias: DB_NAME
+          alias: DB_NAME
         - name: pip-shared-POSTGRES-PASS
-            alias: DB_PASS
+          alias: DB_PASS
         - name: pip-shared-POSTGRES-PORT
-            alias: DB_PORT
+          alias: DB_PORT
         - name: pip-shared-POSTGRES-USER
-            alias: DB_USER
+          alias: DB_USER
   environment:

--- a/charts/pip-account-management/values.yaml
+++ b/charts/pip-account-management/values.yaml
@@ -15,4 +15,12 @@ java:
           alias: TENANT_GUID
         - name: shared-storageaccount-connection-string
           alias: CONNECTION_STRING
+        - name: pip-shared-POSTGRES-DATABASE
+            alias: DB_NAME
+        - name: pip-shared-POSTGRES-PASS
+            alias: DB_PASS
+        - name: pip-shared-POSTGRES-PORT
+            alias: DB_PORT
+        - name: pip-shared-POSTGRES-USER
+            alias: DB_USER
   environment:

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -38,7 +38,7 @@
   </suppress>
   <suppress>
     <notes><![CDATA[
-   tomcat-embed-core-9.0.56.jar
+   file name: netty-tcnative-classes-2.0.46.Final.jar
    ]]></notes>
     <packageUrl regex="true">^pkg:maven/io.netty/netty-tcnative-classes@2.0.46.Final</packageUrl>
     <cve>CVE-2014-3488</cve>

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -38,7 +38,7 @@
   </suppress>
   <suppress>
     <notes><![CDATA[
-   file name: netty-tcnative-classes-2.0.46.Final.jar
+   tomcat-embed-core-9.0.56.jar
    ]]></notes>
     <packageUrl regex="true">^pkg:maven/io.netty/netty-tcnative-classes@2.0.46.Final</packageUrl>
     <cve>CVE-2014-3488</cve>
@@ -51,5 +51,20 @@
     <cve>CVE-2021-21409</cve>
     <cve>CVE-2021-37136</cve>
     <cve>CVE-2021-37137</cve>
+    <cve>CVE-2021-43797</cve>
+  </suppress>
+  <suppress>
+    <notes><![CDATA[
+   file name: tomcat-embed-core-9.0.56.jar
+   ]]></notes>
+    <packageUrl regex="true">^pkg:maven/org.apache.tomcat.embed/tomcat-embed-core@9.0.56</packageUrl>
+    <cve>CVE-2022-23181</cve>
+  </suppress>
+  <suppress>
+    <notes><![CDATA[
+   file name: tomcat-embed-websocket-9.0.56.jar
+   ]]></notes>
+    <packageUrl regex="true">^pkg:maven/org.apache.tomcat.embed/tomcat-embed-websocket@9.0.56</packageUrl>
+    <cve>CVE-2022-23181</cve>
   </suppress>
 </suppressions>

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -53,18 +53,4 @@
     <cve>CVE-2021-37137</cve>
     <cve>CVE-2021-43797</cve>
   </suppress>
-  <suppress>
-    <notes><![CDATA[
-   file name: tomcat-embed-core-9.0.56.jar
-   ]]></notes>
-    <packageUrl regex="true">^pkg:maven/org.apache.tomcat.embed/tomcat-embed-core@9.0.56</packageUrl>
-    <cve>CVE-2022-23181</cve>
-  </suppress>
-  <suppress>
-    <notes><![CDATA[
-   file name: tomcat-embed-websocket-9.0.56.jar
-   ]]></notes>
-    <packageUrl regex="true">^pkg:maven/org.apache.tomcat.embed/tomcat-embed-websocket@9.0.56</packageUrl>
-    <cve>CVE-2022-23181</cve>
-  </suppress>
 </suppressions>

--- a/src/integrationTest/java/uk/gov/hmcts/reform/pip/account/management/controllers/AccountTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/pip/account/management/controllers/AccountTest.java
@@ -76,7 +76,7 @@ class AccountTest {
     private static final UserProvenances PROVENANCE = UserProvenances.PI_AAD;
     private static final Roles ROLE = Roles.INTERNAL_ADMIN_CTSC;
     private static final String ISSUER_EMAIL = "issuer@email.com";
-    private static final String ISSUER_HEADER = "x-user";
+    private static final String ISSUER_HEADER = "x-issuer-email";
 
     private static final String ID = "1234";
 

--- a/src/integrationTest/java/uk/gov/hmcts/reform/pip/account/management/controllers/AccountTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/pip/account/management/controllers/AccountTest.java
@@ -34,6 +34,7 @@ import uk.gov.hmcts.reform.pip.account.management.model.UserProvenances;
 import uk.gov.hmcts.reform.pip.account.management.model.errored.ErroredSubscriber;
 
 import java.util.List;
+import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -95,10 +96,10 @@ class AccountTest {
 
     private ObjectMapper objectMapper;
 
-    private PiUser createUser(boolean valid) {
+    private PiUser createUser(boolean valid, String id) {
         PiUser user = new PiUser();
         user.setEmail(valid ? EMAIL : INVALID_EMAIL);
-        user.setProvenanceUserId(ID);
+        user.setProvenanceUserId(id);
         user.setUserProvenance(PROVENANCE);
         user.setRoles(ROLE);
 
@@ -398,7 +399,7 @@ class AccountTest {
 
     @Test
     void testCreateSingleUser() throws Exception {
-        PiUser validUser = createUser(true);
+        PiUser validUser = createUser(true, UUID.randomUUID().toString());
 
         MockHttpServletRequestBuilder mockHttpServletRequestBuilder = MockMvcRequestBuilders
             .post(PI_URL)
@@ -416,8 +417,8 @@ class AccountTest {
 
     @Test
     void testCreateMultipleSuccessUsers() throws Exception {
-        PiUser validUser1 = createUser(true);
-        PiUser validUser2 = createUser(true);
+        PiUser validUser1 = createUser(true, UUID.randomUUID().toString());
+        PiUser validUser2 = createUser(true, UUID.randomUUID().toString());
 
         MockHttpServletRequestBuilder mockHttpServletRequestBuilder = MockMvcRequestBuilders
             .post(PI_URL)
@@ -435,7 +436,7 @@ class AccountTest {
 
     @Test
     void testCreateSingleErroredUser() throws Exception {
-        PiUser invalidUser = createUser(false);
+        PiUser invalidUser = createUser(false, UUID.randomUUID().toString());
 
         MockHttpServletRequestBuilder mockHttpServletRequestBuilder = MockMvcRequestBuilders
             .post(PI_URL)
@@ -453,8 +454,8 @@ class AccountTest {
 
     @Test
     void testCreateMultipleErroredUsers() throws Exception {
-        PiUser invalidUser1 = createUser(false);
-        PiUser invalidUser2 = createUser(false);
+        PiUser invalidUser1 = createUser(false, UUID.randomUUID().toString());
+        PiUser invalidUser2 = createUser(false, UUID.randomUUID().toString());
 
         MockHttpServletRequestBuilder mockHttpServletRequestBuilder = MockMvcRequestBuilders
             .post(PI_URL)
@@ -472,8 +473,8 @@ class AccountTest {
 
     @Test
     void testCreateMultipleUsersCreateAndErrored() throws Exception {
-        PiUser validUser = createUser(true);
-        PiUser invalidUser = createUser(false);
+        PiUser validUser = createUser(true, UUID.randomUUID().toString());
+        PiUser invalidUser = createUser(false, UUID.randomUUID().toString());
 
         MockHttpServletRequestBuilder mockHttpServletRequestBuilder = MockMvcRequestBuilders
             .post(PI_URL)

--- a/src/integrationTest/java/uk/gov/hmcts/reform/pip/account/management/controllers/AccountTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/pip/account/management/controllers/AccountTest.java
@@ -74,7 +74,7 @@ class AccountTest {
     private static final String SURNAME = "Surname";
     private static final String TITLE = "Title";
     private static final UserProvenances PROVENANCE = UserProvenances.PI_AAD;
-    private static final Roles ROLE = Roles.INTERNAL;
+    private static final Roles ROLE = Roles.INTERNAL_ADMIN_CTSC;
     private static final String ISSUER_EMAIL = "issuer@email.com";
     private static final String ISSUER_HEADER = "x-user";
 

--- a/src/integrationTest/java/uk/gov/hmcts/reform/pip/account/management/controllers/GetWelcomeTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/pip/account/management/controllers/GetWelcomeTest.java
@@ -1,5 +1,6 @@
 package uk.gov.hmcts.reform.pip.account.management.controllers;
 
+import io.zonky.test.db.AutoConfigureEmbeddedDatabase;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -19,6 +20,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
     webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @AutoConfigureMockMvc
 @ActiveProfiles(profiles = "test")
+@AutoConfigureEmbeddedDatabase(type = AutoConfigureEmbeddedDatabase.DatabaseType.POSTGRES)
 class GetWelcomeTest {
 
     @Autowired

--- a/src/main/java/uk/gov/hmcts/reform/pip/account/management/controllers/AccountController.java
+++ b/src/main/java/uk/gov/hmcts/reform/pip/account/management/controllers/AccountController.java
@@ -17,6 +17,7 @@ import uk.gov.hmcts.reform.pip.account.management.model.CreationEnum;
 import uk.gov.hmcts.reform.pip.account.management.model.PiUser;
 import uk.gov.hmcts.reform.pip.account.management.model.Subscriber;
 import uk.gov.hmcts.reform.pip.account.management.service.AccountService;
+import uk.gov.hmcts.reform.pip.account.management.validation.annotations.ValidEmail;
 
 import java.util.List;
 import java.util.Map;
@@ -59,7 +60,7 @@ public class AccountController {
     @ApiOperation("Add a user to the P&I postgres database")
     @PostMapping("/add/pi")
     public ResponseEntity<Map<CreationEnum, List<?>>> createUsers(
-        @RequestHeader("x-user") String issuerEmail,
+        @RequestHeader("x-issuer-email") @ValidEmail String issuerEmail,
         @RequestBody List<PiUser> users) {
         return ResponseEntity.status(HttpStatus.CREATED).body(accountService.addUsers(users, issuerEmail));
     }

--- a/src/main/java/uk/gov/hmcts/reform/pip/account/management/controllers/AccountController.java
+++ b/src/main/java/uk/gov/hmcts/reform/pip/account/management/controllers/AccountController.java
@@ -14,8 +14,8 @@ import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import uk.gov.hmcts.reform.pip.account.management.model.CreationEnum;
-import uk.gov.hmcts.reform.pip.account.management.model.Subscriber;
 import uk.gov.hmcts.reform.pip.account.management.model.PiUser;
+import uk.gov.hmcts.reform.pip.account.management.model.Subscriber;
 import uk.gov.hmcts.reform.pip.account.management.service.AccountService;
 
 import java.util.List;
@@ -49,7 +49,7 @@ public class AccountController {
      * POST endpoint to create a new user in the P&I postgres database.
      *
      * @param issuerEmail The user creating the account.
-     * @param users The list of users to add to the database.
+     * @param users       The list of users to add to the database.
      * @return the uuid of the created and added users with any errored accounts
      */
     @ApiResponses({
@@ -59,7 +59,7 @@ public class AccountController {
     @ApiOperation("Add a user to the P&I postgres database")
     @PostMapping("/add/pi")
     public ResponseEntity<Map<CreationEnum, List<?>>> createUsers(
-        @RequestHeader(value = "x-user") String issuerEmail,
+        @RequestHeader("x-user") String issuerEmail,
         @RequestBody List<PiUser> users) {
         return ResponseEntity.status(HttpStatus.CREATED).body(accountService.addUsers(users, issuerEmail));
     }

--- a/src/main/java/uk/gov/hmcts/reform/pip/account/management/controllers/AccountController.java
+++ b/src/main/java/uk/gov/hmcts/reform/pip/account/management/controllers/AccountController.java
@@ -1,15 +1,21 @@
 package uk.gov.hmcts.reform.pip.account.management.controllers;
 
 import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import uk.gov.hmcts.reform.pip.account.management.model.CreationEnum;
 import uk.gov.hmcts.reform.pip.account.management.model.Subscriber;
+import uk.gov.hmcts.reform.pip.account.management.model.PiUser;
 import uk.gov.hmcts.reform.pip.account.management.service.AccountService;
 
 import java.util.List;
@@ -37,6 +43,25 @@ public class AccountController {
         Map<CreationEnum, List<? extends Subscriber>> processedSubscribers =
             accountService.createSubscribers(subscribers);
         return ResponseEntity.ok(processedSubscribers);
+    }
+
+    /**
+     * POST endpoint to create a new user in the P&I postgres database.
+     *
+     * @param issuerEmail The user creating the account.
+     * @param users The list of users to add to the database.
+     * @return the uuid of the created and added users with any errored accounts
+     */
+    @ApiResponses({
+        @ApiResponse(code = 201,
+            message = "CREATED_ACCOUNTS: [{Created User UUID's}]")
+    })
+    @ApiOperation("Add a user to the P&I postgres database")
+    @PostMapping("/add/pi")
+    public ResponseEntity<Map<CreationEnum, List<?>>> createUsers(
+        @RequestHeader(value = "x-user") String issuerEmail,
+        @RequestBody List<PiUser> users) {
+        return ResponseEntity.status(HttpStatus.CREATED).body(accountService.addUsers(users, issuerEmail));
     }
 
 

--- a/src/main/java/uk/gov/hmcts/reform/pip/account/management/database/UserRepository.java
+++ b/src/main/java/uk/gov/hmcts/reform/pip/account/management/database/UserRepository.java
@@ -1,0 +1,7 @@
+package uk.gov.hmcts.reform.pip.account.management.database;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import uk.gov.hmcts.reform.pip.account.management.model.PiUser;
+
+public interface UserRepository extends JpaRepository<PiUser, Long> {
+}

--- a/src/main/java/uk/gov/hmcts/reform/pip/account/management/database/UserRepository.java
+++ b/src/main/java/uk/gov/hmcts/reform/pip/account/management/database/UserRepository.java
@@ -1,7 +1,16 @@
 package uk.gov.hmcts.reform.pip.account.management.database;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import uk.gov.hmcts.reform.pip.account.management.model.PiUser;
 
+import java.util.List;
+
 public interface UserRepository extends JpaRepository<PiUser, Long> {
+
+    @Query(value = "SELECT * FROM pi_user WHERE provenance_user_id=:provUserId AND user_provenance=:userProv",
+        nativeQuery = true)
+    List<PiUser> findExistingByProvenanceId(@Param("provUserId") String provenanceUserId,
+                                            @Param("userProv") String userProvenance);
 }

--- a/src/main/java/uk/gov/hmcts/reform/pip/account/management/errorhandling/GlobalExceptionHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/pip/account/management/errorhandling/GlobalExceptionHandler.java
@@ -3,10 +3,12 @@ package uk.gov.hmcts.reform.pip.account.management.errorhandling;
 import com.fasterxml.jackson.databind.JsonMappingException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MissingRequestHeaderException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 
 import java.time.LocalDateTime;
+import javax.validation.ConstraintViolationException;
 
 /**
  * Global exception handler, that captures exceptions thrown by the controllers, and encapsulates
@@ -27,6 +29,26 @@ public class GlobalExceptionHandler {
 
         ExceptionResponse exceptionResponse = new ExceptionResponse();
         exceptionResponse.setMessage(ex.getOriginalMessage());
+        exceptionResponse.setTimestamp(LocalDateTime.now());
+
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(exceptionResponse);
+    }
+
+    @ExceptionHandler(MissingRequestHeaderException.class)
+    public ResponseEntity<ExceptionResponse> handle(MissingRequestHeaderException ex) {
+
+        ExceptionResponse exceptionResponse = new ExceptionResponse();
+        exceptionResponse.setMessage(ex.getMessage());
+        exceptionResponse.setTimestamp(LocalDateTime.now());
+
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(exceptionResponse);
+    }
+
+    @ExceptionHandler(ConstraintViolationException.class)
+    public ResponseEntity<ExceptionResponse> handle(ConstraintViolationException ex) {
+
+        ExceptionResponse exceptionResponse = new ExceptionResponse();
+        exceptionResponse.setMessage(ex.getMessage());
         exceptionResponse.setTimestamp(LocalDateTime.now());
 
         return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(exceptionResponse);

--- a/src/main/java/uk/gov/hmcts/reform/pip/account/management/model/AccountStatus.java
+++ b/src/main/java/uk/gov/hmcts/reform/pip/account/management/model/AccountStatus.java
@@ -4,7 +4,5 @@ package uk.gov.hmcts.reform.pip.account.management.model;
  * Enum that represents the status of the account.
  */
 public enum AccountStatus {
-
     ACTIVE
-
 }

--- a/src/main/java/uk/gov/hmcts/reform/pip/account/management/model/PiUser.java
+++ b/src/main/java/uk/gov/hmcts/reform/pip/account/management/model/PiUser.java
@@ -5,6 +5,7 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.Type;
 import uk.gov.hmcts.reform.pip.account.management.validation.annotations.ValidEmail;
+
 import java.util.UUID;
 import javax.persistence.Column;
 import javax.persistence.Entity;
@@ -17,7 +18,7 @@ import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
 
 /**
- * Model that represents the User as exists in P&I database domain
+ * Model that represents the User as exists in P&I database domain.
  */
 @Entity
 @Data

--- a/src/main/java/uk/gov/hmcts/reform/pip/account/management/model/PiUser.java
+++ b/src/main/java/uk/gov/hmcts/reform/pip/account/management/model/PiUser.java
@@ -1,0 +1,61 @@
+package uk.gov.hmcts.reform.pip.account.management.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.Type;
+import uk.gov.hmcts.reform.pip.account.management.validation.annotations.ValidEmail;
+import java.util.UUID;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+
+/**
+ * Model that represents the User as exists in P&I database domain
+ */
+@Entity
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class PiUser {
+
+    /**
+     * The ID of the user as they exist in P&I.
+     */
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    @Column(columnDefinition = "uuid", insertable = false, updatable = false, nullable = false)
+    @Type(type = "org.hibernate.type.PostgresUUIDType")
+    private UUID userId;
+
+    /**
+     * The Sign in entry system the user was added with. (CFT IDAM, Crime IDAM, P&I AAD).
+     */
+    @Enumerated(EnumType.STRING)
+    private UserProvenances userProvenance;
+
+    /**
+     * The user id of the user as per their provenance system.
+     */
+    @NotNull
+    @NotBlank
+    private String provenanceUserId;
+
+    /**
+     * Email of the user.
+     */
+    @ValidEmail
+    private String email;
+
+    /**
+     * Role of the user, Verified, Internal or Technical.
+     */
+    @Enumerated(EnumType.STRING)
+    private Roles roles;
+}

--- a/src/main/java/uk/gov/hmcts/reform/pip/account/management/model/PiUser.java
+++ b/src/main/java/uk/gov/hmcts/reform/pip/account/management/model/PiUser.java
@@ -5,6 +5,7 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.Type;
 import uk.gov.hmcts.reform.pip.account.management.validation.annotations.ValidEmail;
+import uk.gov.hmcts.reform.pip.account.management.validation.annotations.ValidProvenanceUserId;
 
 import java.util.UUID;
 import javax.persistence.Column;
@@ -24,6 +25,7 @@ import javax.validation.constraints.NotNull;
 @Data
 @AllArgsConstructor
 @NoArgsConstructor
+@ValidProvenanceUserId
 public class PiUser {
 
     /**

--- a/src/main/java/uk/gov/hmcts/reform/pip/account/management/model/Roles.java
+++ b/src/main/java/uk/gov/hmcts/reform/pip/account/management/model/Roles.java
@@ -1,5 +1,9 @@
 package uk.gov.hmcts.reform.pip.account.management.model;
 
+/**
+ * Enum of the roles allowed for users of P&I, verified are media members, Internal are different levels of admin,
+ * and Technical are consumers of our service such as Courtel.
+ */
 public enum Roles {
     VERIFIED,
     INTERNAL_SUPER_ADMIN_CTSC,

--- a/src/main/java/uk/gov/hmcts/reform/pip/account/management/model/Roles.java
+++ b/src/main/java/uk/gov/hmcts/reform/pip/account/management/model/Roles.java
@@ -2,6 +2,9 @@ package uk.gov.hmcts.reform.pip.account.management.model;
 
 public enum Roles {
     VERIFIED,
-    INTERNAL,
+    INTERNAL_SUPER_ADMIN_CTSC,
+    INTERNAL_SUPER_ADMIN_LOCAL,
+    INTERNAL_ADMIN_CTSC,
+    INTERNAL_ADMIN_LOCAL,
     TECHNICAL
 }

--- a/src/main/java/uk/gov/hmcts/reform/pip/account/management/model/Roles.java
+++ b/src/main/java/uk/gov/hmcts/reform/pip/account/management/model/Roles.java
@@ -1,0 +1,7 @@
+package uk.gov.hmcts.reform.pip.account.management.model;
+
+public enum Roles {
+    VERIFIED,
+    INTERNAL,
+    TECHNICAL
+}

--- a/src/main/java/uk/gov/hmcts/reform/pip/account/management/model/UserProvenances.java
+++ b/src/main/java/uk/gov/hmcts/reform/pip/account/management/model/UserProvenances.java
@@ -1,0 +1,7 @@
+package uk.gov.hmcts.reform.pip.account.management.model;
+
+public enum UserProvenances {
+    CFT_IDAM,
+    CRIME_IDAM,
+    PI_AAD
+}

--- a/src/main/java/uk/gov/hmcts/reform/pip/account/management/model/UserProvenances.java
+++ b/src/main/java/uk/gov/hmcts/reform/pip/account/management/model/UserProvenances.java
@@ -1,5 +1,9 @@
 package uk.gov.hmcts.reform.pip.account.management.model;
 
+/**
+ * Provenance of where the user being added is coming from, if they have been added through the IDAM's or P&I, then
+ * the userProvenanceId in PiUser relates to the unique identifier of the Provenance selected.
+ */
 public enum UserProvenances {
     CFT_IDAM,
     CRIME_IDAM,

--- a/src/main/java/uk/gov/hmcts/reform/pip/account/management/model/errored/ErroredPiUser.java
+++ b/src/main/java/uk/gov/hmcts/reform/pip/account/management/model/errored/ErroredPiUser.java
@@ -1,0 +1,32 @@
+package uk.gov.hmcts.reform.pip.account.management.model.errored;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import uk.gov.hmcts.reform.pip.account.management.model.PiUser;
+import java.util.List;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+public class ErroredPiUser extends PiUser {
+
+    /**
+     * This is the error messages for why the user has failed to be created.
+     */
+    private List<String> errorMessages;
+
+    /**
+     * Constructor that takes in an existing subscriber and converts it to an errored subscriber.
+     * @param user The subscriber to be converted to an errored subscriber.
+     */
+    public ErroredPiUser(PiUser user) {
+        super(user.getUserId(),
+              user.getUserProvenance(),
+              user.getProvenanceUserId(),
+              user.getEmail(),
+              user.getRoles());
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/pip/account/management/model/errored/ErroredPiUser.java
+++ b/src/main/java/uk/gov/hmcts/reform/pip/account/management/model/errored/ErroredPiUser.java
@@ -5,6 +5,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import uk.gov.hmcts.reform.pip.account.management.model.PiUser;
+
 import java.util.List;
 
 @Getter

--- a/src/main/java/uk/gov/hmcts/reform/pip/account/management/model/errored/ErroredSubscriber.java
+++ b/src/main/java/uk/gov/hmcts/reform/pip/account/management/model/errored/ErroredSubscriber.java
@@ -1,9 +1,10 @@
-package uk.gov.hmcts.reform.pip.account.management.model;
+package uk.gov.hmcts.reform.pip.account.management.model.errored;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import uk.gov.hmcts.reform.pip.account.management.model.Subscriber;
 
 import java.util.List;
 

--- a/src/main/java/uk/gov/hmcts/reform/pip/account/management/service/AccountService.java
+++ b/src/main/java/uk/gov/hmcts/reform/pip/account/management/service/AccountService.java
@@ -90,7 +90,7 @@ public class AccountService {
      * success or failure lists.
      * @param users the list of users to be added.
      * @param issuerEmail the email of the admin adding the users for logging purposes.
-     * @return
+     * @return Map of Created and Errored accounts, created has UUID's and errored has user objects.
      */
     public Map<CreationEnum, List<?>> addUsers(List<PiUser> users, String issuerEmail) {
         List<UUID> createdAccounts = new ArrayList<>();

--- a/src/main/java/uk/gov/hmcts/reform/pip/account/management/service/AccountService.java
+++ b/src/main/java/uk/gov/hmcts/reform/pip/account/management/service/AccountService.java
@@ -12,6 +12,7 @@ import uk.gov.hmcts.reform.pip.account.management.model.Subscriber;
 import uk.gov.hmcts.reform.pip.account.management.model.errored.ErroredPiUser;
 import uk.gov.hmcts.reform.pip.account.management.model.errored.ErroredSubscriber;
 import uk.gov.hmcts.reform.pip.model.enums.UserActions;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;

--- a/src/main/java/uk/gov/hmcts/reform/pip/account/management/service/AccountService.java
+++ b/src/main/java/uk/gov/hmcts/reform/pip/account/management/service/AccountService.java
@@ -1,26 +1,34 @@
 package uk.gov.hmcts.reform.pip.account.management.service;
 
 import com.microsoft.graph.models.User;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
+import uk.gov.hmcts.reform.pip.account.management.database.UserRepository;
 import uk.gov.hmcts.reform.pip.account.management.errorhandling.exceptions.AzureCustomException;
 import uk.gov.hmcts.reform.pip.account.management.model.CreationEnum;
-import uk.gov.hmcts.reform.pip.account.management.model.ErroredSubscriber;
+import uk.gov.hmcts.reform.pip.account.management.model.PiUser;
 import uk.gov.hmcts.reform.pip.account.management.model.Subscriber;
-
+import uk.gov.hmcts.reform.pip.account.management.model.errored.ErroredPiUser;
+import uk.gov.hmcts.reform.pip.account.management.model.errored.ErroredSubscriber;
+import uk.gov.hmcts.reform.pip.model.enums.UserActions;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 import javax.validation.ConstraintViolation;
 import javax.validation.Validator;
 
+import static uk.gov.hmcts.reform.pip.model.LogBuilder.writeLog;
+
 /**
  * Service layer that deals with the creation of accounts.
- * The storage mechanism (e.g Azure) is seperated into a seperate class.
+ * The storage mechanism (e.g Azure) is seperated into a separate class.
  */
+@Slf4j
 @Component
 public class AccountService {
 
@@ -29,6 +37,9 @@ public class AccountService {
 
     @Autowired
     AzureUserService azureUserService;
+
+    @Autowired
+    UserRepository userRepository;
 
     /**
      * Method to create new subscribers.
@@ -70,6 +81,33 @@ public class AccountService {
         processedAccounts.put(CreationEnum.CREATED_ACCOUNTS, createdAccounts);
         processedAccounts.put(CreationEnum.ERRORED_ACCOUNTS, erroredAccounts);
 
+        return processedAccounts;
+    }
+
+    public Map<CreationEnum, List<?>> addUsers(List<PiUser> users, String issuerEmail) {
+        List<UUID> createdAccounts = new ArrayList<>();
+        List<ErroredPiUser> erroredAccounts = new ArrayList<>();
+
+        for (PiUser user : users) {
+            Set<ConstraintViolation<PiUser>> constraintViolationSet = validator.validate(user);
+            if (!constraintViolationSet.isEmpty()) {
+                ErroredPiUser erroredUser = new ErroredPiUser(user);
+                erroredUser.setErrorMessages(constraintViolationSet
+                                                 .stream().map(ConstraintViolation::getMessage)
+                                                 .collect(Collectors.toList()));
+                erroredAccounts.add(erroredUser);
+                continue;
+            }
+
+            PiUser addedUser = userRepository.save(user);
+            createdAccounts.add(addedUser.getUserId());
+
+            log.info(writeLog(issuerEmail, UserActions.CREATE_ACCOUNT, addedUser.getEmail()));
+        }
+
+        Map<CreationEnum, List<?>> processedAccounts = new ConcurrentHashMap<>();
+        processedAccounts.put(CreationEnum.CREATED_ACCOUNTS, createdAccounts);
+        processedAccounts.put(CreationEnum.ERRORED_ACCOUNTS, erroredAccounts);
         return processedAccounts;
     }
 

--- a/src/main/java/uk/gov/hmcts/reform/pip/account/management/service/AccountService.java
+++ b/src/main/java/uk/gov/hmcts/reform/pip/account/management/service/AccountService.java
@@ -85,6 +85,13 @@ public class AccountService {
         return processedAccounts;
     }
 
+    /**
+     * Method to add users to P&I database, loops through the list and validates the email provided then adds them to
+     * success or failure lists.
+     * @param users the list of users to be added.
+     * @param issuerEmail the email of the admin adding the users for logging purposes.
+     * @return
+     */
     public Map<CreationEnum, List<?>> addUsers(List<PiUser> users, String issuerEmail) {
         List<UUID> createdAccounts = new ArrayList<>();
         List<ErroredPiUser> erroredAccounts = new ArrayList<>();

--- a/src/main/java/uk/gov/hmcts/reform/pip/account/management/validation/annotations/ValidProvenanceUserId.java
+++ b/src/main/java/uk/gov/hmcts/reform/pip/account/management/validation/annotations/ValidProvenanceUserId.java
@@ -1,6 +1,6 @@
 package uk.gov.hmcts.reform.pip.account.management.validation.annotations;
 
-import uk.gov.hmcts.reform.pip.account.management.validation.validator.EmailValidator;
+import uk.gov.hmcts.reform.pip.account.management.validation.validator.ProvenanceUserIdValidator;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
@@ -10,17 +10,16 @@ import javax.validation.Constraint;
 import javax.validation.Payload;
 
 /**
- * Annotation that is used to start the email Validator.
+ * Annotation that is used to start the provenance user id Validator.
  */
-@Target({ElementType.METHOD, ElementType.FIELD, ElementType.PARAMETER})
+@Target({ElementType.METHOD, ElementType.FIELD, ElementType.TYPE})
 @Retention(RetentionPolicy.RUNTIME)
-@Constraint(validatedBy = EmailValidator.class)
-public @interface ValidEmail {
+@Constraint(validatedBy = ProvenanceUserIdValidator.class)
+public @interface ValidProvenanceUserId {
 
-    String message() default "Invalid email provided. Email must contain an @ symbol";
+    String message() default "Invalid Provenance User Id provided, already exists.";
 
     Class<?>[] groups() default {};
 
     Class<? extends Payload>[] payload() default {};
-
 }

--- a/src/main/java/uk/gov/hmcts/reform/pip/account/management/validation/validator/ProvenanceUserIdValidator.java
+++ b/src/main/java/uk/gov/hmcts/reform/pip/account/management/validation/validator/ProvenanceUserIdValidator.java
@@ -1,0 +1,23 @@
+package uk.gov.hmcts.reform.pip.account.management.validation.validator;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import uk.gov.hmcts.reform.pip.account.management.database.UserRepository;
+import uk.gov.hmcts.reform.pip.account.management.model.PiUser;
+import uk.gov.hmcts.reform.pip.account.management.validation.annotations.ValidProvenanceUserId;
+
+import java.util.List;
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+
+public class ProvenanceUserIdValidator implements ConstraintValidator<ValidProvenanceUserId, PiUser> {
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Override
+    public boolean isValid(PiUser piUser, ConstraintValidatorContext constraintValidatorContext) {
+        List<PiUser> existingUsers = userRepository.findExistingByProvenanceId(piUser.getProvenanceUserId(),
+                                                                               piUser.getUserProvenance().name());
+        return existingUsers.isEmpty();
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/pip/account/management/validation/validator/ProvenanceUserIdValidator.java
+++ b/src/main/java/uk/gov/hmcts/reform/pip/account/management/validation/validator/ProvenanceUserIdValidator.java
@@ -16,8 +16,13 @@ public class ProvenanceUserIdValidator implements ConstraintValidator<ValidProve
 
     @Override
     public boolean isValid(PiUser piUser, ConstraintValidatorContext constraintValidatorContext) {
-        List<PiUser> existingUsers = userRepository.findExistingByProvenanceId(piUser.getProvenanceUserId(),
-                                                                               piUser.getUserProvenance().name());
-        return existingUsers.isEmpty();
+        if (userRepository != null) {
+            List<PiUser> existingUsers = userRepository.findExistingByProvenanceId(
+                piUser.getProvenanceUserId(),
+                piUser.getUserProvenance().name()
+            );
+            return existingUsers.isEmpty();
+        }
+        return true;
     }
 }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -15,11 +15,35 @@ management:
 spring:
   config:
     import: "optional:configtree:/mnt/secrets/pip-ss-kv/"
-  jackson:
-    parser:
-      STRICT_DUPLICATE_DETECTION: true
   application:
     name: Account Management
+  datasource:
+    driver-class-name: org.postgresql.Driver
+
+    url: jdbc:postgresql://${DB_NAME}.postgres.database.azure.com:${DB_PORT}/postgres
+    username: ${DB_USER}
+    password: ${DB_PASS}
+    properties:
+      charSet: UTF-8
+    #    hikari:
+    #      minimumIdle: 2
+    #      maximumPoolSize: 10
+    #      idleTimeout: 10000
+    #      poolName: {to-be-defined}HikariCP
+    #      maxLifetime: 7200000
+    #      connectionTimeout: 30000
+  jpa:
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.PostgreSQL81Dialect
+        jdbc:
+          lob:
+            non_contextual_creation: true
+    database: POSTGRESQL
+    generate-ddl: 'true'
+    hibernate:
+      # this ensures the db persists after spring boot connection drops.
+      ddl-auto: update
 
 azure:
   application-insights:

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -28,13 +28,6 @@ spring:
     password: ${DB_PASS}
     properties:
       charSet: UTF-8
-    #    hikari:
-    #      minimumIdle: 2
-    #      maximumPoolSize: 10
-    #      idleTimeout: 10000
-    #      poolName: {to-be-defined}HikariCP
-    #      maxLifetime: 7200000
-    #      connectionTimeout: 30000
   jpa:
     properties:
       hibernate:

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -15,6 +15,9 @@ management:
 spring:
   config:
     import: "optional:configtree:/mnt/secrets/pip-ss-kv/"
+  jackson:
+    parser:
+      STRICT_DUPLICATE_DETECTION: true
   application:
     name: Account Management
   datasource:

--- a/src/test/java/uk/gov/hmcts/reform/pip/account/management/controllers/AccountControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/pip/account/management/controllers/AccountControllerTest.java
@@ -7,7 +7,6 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import uk.gov.hmcts.reform.pip.account.management.database.UserRepository;
 import uk.gov.hmcts.reform.pip.account.management.model.CreationEnum;
 import uk.gov.hmcts.reform.pip.account.management.model.PiUser;
 import uk.gov.hmcts.reform.pip.account.management.model.Subscriber;

--- a/src/test/java/uk/gov/hmcts/reform/pip/account/management/controllers/AccountControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/pip/account/management/controllers/AccountControllerTest.java
@@ -7,7 +7,9 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import uk.gov.hmcts.reform.pip.account.management.database.UserRepository;
 import uk.gov.hmcts.reform.pip.account.management.model.CreationEnum;
+import uk.gov.hmcts.reform.pip.account.management.model.PiUser;
 import uk.gov.hmcts.reform.pip.account.management.model.Subscriber;
 import uk.gov.hmcts.reform.pip.account.management.service.AccountService;
 
@@ -45,6 +47,25 @@ class AccountControllerTest {
 
         assertEquals(HttpStatus.OK, response.getStatusCode(), "Should return an OK status code");
         assertEquals(subscribersMap, response.getBody(), "Should return the expected subscribers map");
+    }
+
+    @Test
+    void testCreateUser() {
+        Map<CreationEnum, List<?>> usersMap = new ConcurrentHashMap<>();
+        usersMap.put(CreationEnum.CREATED_ACCOUNTS, List.of(new PiUser()));
+
+        PiUser user = new PiUser();
+        user.setEmail("a@b.com");
+
+        List<PiUser> users = List.of(user);
+
+        when(accountService.addUsers(users, "test")).thenReturn(usersMap);
+
+        ResponseEntity<Map<CreationEnum, List<?>>> response = accountController.createUsers("test", users);
+
+        assertEquals(HttpStatus.CREATED, response.getStatusCode(),
+                     "Should return created status");
+        assertEquals(usersMap, response.getBody(), "Should return the expected user map");
     }
 
 }

--- a/src/test/java/uk/gov/hmcts/reform/pip/account/management/service/AccountServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/pip/account/management/service/AccountServiceTest.java
@@ -182,7 +182,7 @@ class AccountServiceTest {
 
     @Test
     void testAddUsers() {
-        PiUser user = new PiUser(UUID.randomUUID(), UserProvenances.PI_AAD, ID, EMAIL, Roles.INTERNAL);
+        PiUser user = new PiUser(UUID.randomUUID(), UserProvenances.PI_AAD, ID, EMAIL, Roles.INTERNAL_ADMIN_CTSC);
         Map<CreationEnum, List<?>> expected = new ConcurrentHashMap<>();
         expected.put(CreationEnum.CREATED_ACCOUNTS, List.of(user.getUserId()));
         expected.put(CreationEnum.ERRORED_ACCOUNTS, List.of());
@@ -195,7 +195,8 @@ class AccountServiceTest {
 
     @Test
     void testAddUsersBuildsErrored() {
-        PiUser user = new PiUser(UUID.randomUUID(), UserProvenances.PI_AAD, ID, INVALID_EMAIL, Roles.INTERNAL);
+        PiUser user = new PiUser(UUID.randomUUID(), UserProvenances.PI_AAD, ID, INVALID_EMAIL,
+                                 Roles.INTERNAL_ADMIN_CTSC);
         ErroredPiUser erroredUser = new ErroredPiUser(user);
         erroredUser.setErrorMessages(List.of(VALIDATION_MESSAGE));
         Map<CreationEnum, List<?>> expected = new ConcurrentHashMap<>();
@@ -212,9 +213,9 @@ class AccountServiceTest {
     @Test
     void testAddUsersForBothCreatedAndErrored() {
         PiUser invalidUser = new PiUser(UUID.randomUUID(), UserProvenances.PI_AAD, ID, INVALID_EMAIL,
-                                        Roles.INTERNAL
+                                        Roles.INTERNAL_ADMIN_CTSC
         );
-        PiUser validUser = new PiUser(UUID.randomUUID(), UserProvenances.PI_AAD, ID, EMAIL, Roles.INTERNAL);
+        PiUser validUser = new PiUser(UUID.randomUUID(), UserProvenances.PI_AAD, ID, EMAIL, Roles.INTERNAL_ADMIN_CTSC);
         ErroredPiUser erroredUser = new ErroredPiUser(invalidUser);
         erroredUser.setErrorMessages(List.of(VALIDATION_MESSAGE));
         Map<CreationEnum, List<?>> expected = new ConcurrentHashMap<>();

--- a/src/test/java/uk/gov/hmcts/reform/pip/account/management/service/AccountServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/pip/account/management/service/AccountServiceTest.java
@@ -11,10 +11,10 @@ import uk.gov.hmcts.reform.pip.account.management.errorhandling.exceptions.Azure
 import uk.gov.hmcts.reform.pip.account.management.model.CreationEnum;
 import uk.gov.hmcts.reform.pip.account.management.model.PiUser;
 import uk.gov.hmcts.reform.pip.account.management.model.Roles;
+import uk.gov.hmcts.reform.pip.account.management.model.Subscriber;
 import uk.gov.hmcts.reform.pip.account.management.model.UserProvenances;
 import uk.gov.hmcts.reform.pip.account.management.model.errored.ErroredPiUser;
 import uk.gov.hmcts.reform.pip.account.management.model.errored.ErroredSubscriber;
-import uk.gov.hmcts.reform.pip.account.management.model.Subscriber;
 
 import java.util.List;
 import java.util.Map;
@@ -67,7 +67,7 @@ class AccountServiceTest {
         expectedUser.givenName = "Test";
         expectedUser.id = ID;
 
-        when(validator.validate(argThat(sub -> ((Subscriber)sub).getEmail().equals(subscriber.getEmail()))))
+        when(validator.validate(argThat(sub -> ((Subscriber) sub).getEmail().equals(subscriber.getEmail()))))
             .thenReturn(Set.of());
 
         when(azureUserService.createUser(argThat(user -> user.getEmail().equals(subscriber.getEmail()))))
@@ -83,7 +83,8 @@ class AccountServiceTest {
         assertEquals(ID, subscriber.getAzureSubscriberId(), "Subscriber should have azure "
             + "object ID");
         assertEquals(0, createdSubscribers.get(CreationEnum.ERRORED_ACCOUNTS).size(),
-                     "Map should have no errored accounts");
+                     "Map should have no errored accounts"
+        );
     }
 
     @Test
@@ -91,7 +92,7 @@ class AccountServiceTest {
         Subscriber subscriber = new Subscriber();
         subscriber.setEmail(EMAIL);
 
-        when(validator.validate(argThat(sub -> ((Subscriber)sub).getEmail().equals(subscriber.getEmail()))))
+        when(validator.validate(argThat(sub -> ((Subscriber) sub).getEmail().equals(subscriber.getEmail()))))
             .thenReturn(Set.of());
 
         when(azureUserService.createUser(argThat(user -> user.getEmail().equals(subscriber.getEmail()))))
@@ -104,10 +105,12 @@ class AccountServiceTest {
         List<? extends Subscriber> subscribers = createdSubscribers.get(CreationEnum.ERRORED_ACCOUNTS);
         assertEquals(subscriber.getEmail(), subscribers.get(0).getEmail(), EMAIL_VALIDATION_MESSAGE);
         assertNull(subscriber.getAzureSubscriberId(), "Subscriber should have no azure ID set");
-        assertEquals(ERROR_MESSAGE, ((ErroredSubscriber)subscribers.get(0)).getErrorMessages().get(0),
-                     "Subscriber should have error message set when failed");
+        assertEquals(ERROR_MESSAGE, ((ErroredSubscriber) subscribers.get(0)).getErrorMessages().get(0),
+                     "Subscriber should have error message set when failed"
+        );
         assertEquals(0, createdSubscribers.get(CreationEnum.CREATED_ACCOUNTS).size(),
-                     "Map should have no created accounts");
+                     "Map should have no created accounts"
+        );
     }
 
     @Test
@@ -115,7 +118,7 @@ class AccountServiceTest {
         Subscriber subscriber = new Subscriber();
         subscriber.setEmail(EMAIL);
 
-        when(validator.validate(argThat(sub -> ((Subscriber)sub).getEmail().equals(subscriber.getEmail()))))
+        when(validator.validate(argThat(sub -> ((Subscriber) sub).getEmail().equals(subscriber.getEmail()))))
             .thenReturn(Set.of(constraintViolation));
 
         when(constraintViolation.getMessage()).thenReturn(VALIDATION_MESSAGE);
@@ -128,11 +131,13 @@ class AccountServiceTest {
         assertEquals(subscriber.getEmail(), subscribers.get(0).getEmail(), EMAIL_VALIDATION_MESSAGE);
         assertNull(subscriber.getAzureSubscriberId(), "Subscriber should have no azure ID set");
 
-        assertEquals(VALIDATION_MESSAGE, ((ErroredSubscriber)subscribers.get(0)).getErrorMessages().get(0),
-                     "Subscriber should have error message set when validation has failed");
+        assertEquals(VALIDATION_MESSAGE, ((ErroredSubscriber) subscribers.get(0)).getErrorMessages().get(0),
+                     "Subscriber should have error message set when validation has failed"
+        );
 
         assertEquals(0, createdSubscribers.get(CreationEnum.CREATED_ACCOUNTS).size(),
-                     "Map should have no created accounts");
+                     "Map should have no created accounts"
+        );
     }
 
     @Test
@@ -147,10 +152,10 @@ class AccountServiceTest {
         expectedUser.givenName = "Test";
         expectedUser.id = ID;
 
-        doReturn(Set.of()).when(validator).validate(argThat(sub -> ((Subscriber)sub)
+        doReturn(Set.of()).when(validator).validate(argThat(sub -> ((Subscriber) sub)
             .getEmail().equals(subscriber.getEmail())));
 
-        doReturn(Set.of(constraintViolation)).when(validator).validate(argThat(sub -> ((Subscriber)sub)
+        doReturn(Set.of(constraintViolation)).when(validator).validate(argThat(sub -> ((Subscriber) sub)
             .getEmail().equals(erroredSubscriber.getEmail())));
 
         when(constraintViolation.getMessage()).thenReturn(VALIDATION_MESSAGE);
@@ -169,14 +174,15 @@ class AccountServiceTest {
         assertTrue(createdSubscribers.containsKey(CreationEnum.ERRORED_ACCOUNTS), ERRORED_ACCOUNTS_VALIDATION_MESSAGE);
         List<? extends Subscriber> erroredSubscribers = createdSubscribers.get(CreationEnum.ERRORED_ACCOUNTS);
         assertEquals(erroredSubscriber.getEmail(), erroredSubscribers.get(0).getEmail(), EMAIL_VALIDATION_MESSAGE);
-        assertEquals(VALIDATION_MESSAGE, ((ErroredSubscriber)erroredSubscribers.get(0)).getErrorMessages().get(0),
-                     "Validation message displayed for errored subscriber");
+        assertEquals(VALIDATION_MESSAGE, ((ErroredSubscriber) erroredSubscribers.get(0)).getErrorMessages().get(0),
+                     "Validation message displayed for errored subscriber"
+        );
 
     }
 
     @Test
     void testAddUsers() {
-        PiUser user = new PiUser(UUID.randomUUID(), UserProvenances.PI_AAD, "234", EMAIL, Roles.INTERNAL);
+        PiUser user = new PiUser(UUID.randomUUID(), UserProvenances.PI_AAD, ID, EMAIL, Roles.INTERNAL);
         Map<CreationEnum, List<?>> expected = new ConcurrentHashMap<>();
         expected.put(CreationEnum.CREATED_ACCOUNTS, List.of(user.getUserId()));
         expected.put(CreationEnum.ERRORED_ACCOUNTS, List.of());
@@ -189,7 +195,7 @@ class AccountServiceTest {
 
     @Test
     void testAddUsersBuildsErrored() {
-        PiUser user = new PiUser(UUID.randomUUID(), UserProvenances.PI_AAD, "234", INVALID_EMAIL, Roles.INTERNAL);
+        PiUser user = new PiUser(UUID.randomUUID(), UserProvenances.PI_AAD, ID, INVALID_EMAIL, Roles.INTERNAL);
         ErroredPiUser erroredUser = new ErroredPiUser(user);
         erroredUser.setErrorMessages(List.of(VALIDATION_MESSAGE));
         Map<CreationEnum, List<?>> expected = new ConcurrentHashMap<>();
@@ -205,9 +211,10 @@ class AccountServiceTest {
 
     @Test
     void testAddUsersForBothCreatedAndErrored() {
-        PiUser invalidUser = new PiUser(UUID.randomUUID(), UserProvenances.PI_AAD, "234", INVALID_EMAIL,
-                                        Roles.INTERNAL);
-        PiUser validUser = new PiUser(UUID.randomUUID(), UserProvenances.PI_AAD, "234", EMAIL, Roles.INTERNAL);
+        PiUser invalidUser = new PiUser(UUID.randomUUID(), UserProvenances.PI_AAD, ID, INVALID_EMAIL,
+                                        Roles.INTERNAL
+        );
+        PiUser validUser = new PiUser(UUID.randomUUID(), UserProvenances.PI_AAD, ID, EMAIL, Roles.INTERNAL);
         ErroredPiUser erroredUser = new ErroredPiUser(invalidUser);
         erroredUser.setErrorMessages(List.of(VALIDATION_MESSAGE));
         Map<CreationEnum, List<?>> expected = new ConcurrentHashMap<>();
@@ -222,7 +229,8 @@ class AccountServiceTest {
         when(userRepository.save(validUser)).thenReturn(validUser);
 
         assertEquals(expected, accountService.addUsers(List.of(invalidUser, validUser), EMAIL),
-                     "Returned maps should match created and errored");
+                     "Returned maps should match created and errored"
+        );
     }
 
 }

--- a/src/test/java/uk/gov/hmcts/reform/pip/account/management/validation/validator/ProvenanceUserIdValidatorTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/pip/account/management/validation/validator/ProvenanceUserIdValidatorTest.java
@@ -1,0 +1,56 @@
+package uk.gov.hmcts.reform.pip.account.management.validation.validator;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.hmcts.reform.pip.account.management.database.UserRepository;
+import uk.gov.hmcts.reform.pip.account.management.model.PiUser;
+import uk.gov.hmcts.reform.pip.account.management.model.Roles;
+import uk.gov.hmcts.reform.pip.account.management.model.UserProvenances;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.lenient;
+
+@ExtendWith(MockitoExtension.class)
+class ProvenanceUserIdValidatorTest {
+
+    private final PiUser piUser = new PiUser();
+
+    @Mock
+    UserRepository userRepository;
+
+    @InjectMocks
+    ProvenanceUserIdValidator provenanceUserIdValidator;
+
+    @BeforeEach
+    void setup() {
+        piUser.setUserProvenance(UserProvenances.PI_AAD);
+        piUser.setRoles(Roles.INTERNAL_ADMIN_CTSC);
+        piUser.setEmail("email@email.com");
+        piUser.setProvenanceUserId("123");
+        lenient().when(userRepository.findExistingByProvenanceId(piUser.getProvenanceUserId(),
+                                                        piUser.getUserProvenance().name()))
+            .thenReturn(List.of());
+        lenient().when(userRepository.findExistingByProvenanceId("321", piUser.getUserProvenance().name()))
+            .thenReturn(List.of(piUser));
+    }
+
+    @Test
+    void testUniqueUserReturnsTrue() {
+        assertTrue(provenanceUserIdValidator.isValid(piUser, null),
+                   "Unique user should return true");
+    }
+
+    @Test
+    void testExistingUserReturnsFalse() {
+        piUser.setProvenanceUserId("321");
+        assertFalse(provenanceUserIdValidator.isValid(piUser, null),
+                    "Existing users should return false");
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/pip/account/management/validation/validator/ProvenanceUserIdValidatorTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/pip/account/management/validation/validator/ProvenanceUserIdValidatorTest.java
@@ -53,4 +53,11 @@ class ProvenanceUserIdValidatorTest {
         assertFalse(provenanceUserIdValidator.isValid(piUser, null),
                     "Existing users should return false");
     }
+
+    @Test
+    void testNullRepositoryReturnsTrue() {
+        ProvenanceUserIdValidator provenanceUserIdValidator = new ProvenanceUserIdValidator();
+        assertTrue(provenanceUserIdValidator.isValid(piUser, null),
+                   "Should return true");
+    }
 }


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/PUB-1071


### Change description ###
Added new api for adding users to the P&I user table, this will take in a PiUser object and try add them to the table, if the model is invalid it will return the user as part of an errored list. 

checks validity on email the same way the azure add checks email validity

logging added to capture admin action of creating user


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
