### PR TITLE
Pub 1154 check user provenance

### DIFF
--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -53,4 +53,11 @@
     <cve>CVE-2021-37137</cve>
     <cve>CVE-2021-43797</cve>
   </suppress>
+  <suppress>
+    <notes><![CDATA[
+   file name: jackson-databind-2.12.6.jar
+   ]]></notes>
+    <packageUrl regex="true">^pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.12.6</packageUrl>
+    <cve>CVE-2020-36518</cve>
+  </suppress>
 </suppressions>

--- a/src/main/java/uk/gov/hmcts/reform/pip/account/management/controllers/AccountController.java
+++ b/src/main/java/uk/gov/hmcts/reform/pip/account/management/controllers/AccountController.java
@@ -89,7 +89,7 @@ public class AccountController {
     })
     @ApiOperation("Check if a user can see a classified publication through list type and their provenance")
     @GetMapping("/isAuthorised/{userId}/{listType}")
-    public ResponseEntity<Boolean> isUserAuthorised(@PathVariable UUID userId, @PathVariable ListType listType) {
+    public ResponseEntity<Boolean> checkUserAuthorised(@PathVariable UUID userId, @PathVariable ListType listType) {
         return ResponseEntity.ok(accountService.isUserAuthorisedForPublication(userId, listType));
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/pip/account/management/controllers/AccountController.java
+++ b/src/main/java/uk/gov/hmcts/reform/pip/account/management/controllers/AccountController.java
@@ -8,12 +8,15 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import uk.gov.hmcts.reform.pip.account.management.model.CreationEnum;
+import uk.gov.hmcts.reform.pip.account.management.model.ListType;
 import uk.gov.hmcts.reform.pip.account.management.model.PiUser;
 import uk.gov.hmcts.reform.pip.account.management.model.Subscriber;
 import uk.gov.hmcts.reform.pip.account.management.service.AccountService;
@@ -21,6 +24,7 @@ import uk.gov.hmcts.reform.pip.account.management.validation.annotations.ValidEm
 
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 
 @RestController
 @Api(tags = "Account Management - API for managing accounts")
@@ -65,5 +69,14 @@ public class AccountController {
         return ResponseEntity.status(HttpStatus.CREATED).body(accountService.addUsers(users, issuerEmail));
     }
 
-
+    @ApiResponses({
+        @ApiResponse(code = 200, message = "User has access to provided publication"),
+        @ApiResponse(code = 403, message = "User is not permitted to see provided publication"),
+        @ApiResponse(code = 404, message = "User not found"),
+    })
+    @ApiOperation("Check if a user can see a classified publication through list type and their provenance")
+    @GetMapping("/isAuthorised/{userId}/{listType}")
+    public ResponseEntity<Boolean> isUserAuthorised(@PathVariable UUID userId, @PathVariable ListType listType) {
+        return ResponseEntity.ok(accountService.isUserAuthorisedForPublication(userId, listType));
+    }
 }

--- a/src/main/java/uk/gov/hmcts/reform/pip/account/management/database/UserRepository.java
+++ b/src/main/java/uk/gov/hmcts/reform/pip/account/management/database/UserRepository.java
@@ -6,6 +6,8 @@ import org.springframework.data.repository.query.Param;
 import uk.gov.hmcts.reform.pip.account.management.model.PiUser;
 
 import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
 
 public interface UserRepository extends JpaRepository<PiUser, Long> {
 
@@ -13,4 +15,6 @@ public interface UserRepository extends JpaRepository<PiUser, Long> {
         nativeQuery = true)
     List<PiUser> findExistingByProvenanceId(@Param("provUserId") String provenanceUserId,
                                             @Param("userProv") String userProvenance);
+
+    Optional<PiUser> findByUserId(UUID userId);
 }

--- a/src/main/java/uk/gov/hmcts/reform/pip/account/management/errorhandling/GlobalExceptionHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/pip/account/management/errorhandling/GlobalExceptionHandler.java
@@ -6,6 +6,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MissingRequestHeaderException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
+import uk.gov.hmcts.reform.pip.account.management.errorhandling.exceptions.ForbiddenPermissionsException;
 
 import java.time.LocalDateTime;
 import javax.validation.ConstraintViolationException;
@@ -52,6 +53,15 @@ public class GlobalExceptionHandler {
         exceptionResponse.setTimestamp(LocalDateTime.now());
 
         return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(exceptionResponse);
+    }
+
+    @ExceptionHandler(ForbiddenPermissionsException.class)
+    public ResponseEntity<ExceptionResponse> handle(ForbiddenPermissionsException ex) {
+        ExceptionResponse exceptionResponse = new ExceptionResponse();
+        exceptionResponse.setMessage(ex.getMessage());
+        exceptionResponse.setTimestamp(LocalDateTime.now());
+
+        return ResponseEntity.status(HttpStatus.FORBIDDEN).body(exceptionResponse);
     }
 
 }

--- a/src/main/java/uk/gov/hmcts/reform/pip/account/management/errorhandling/GlobalExceptionHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/pip/account/management/errorhandling/GlobalExceptionHandler.java
@@ -8,6 +8,7 @@ import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import uk.gov.hmcts.reform.pip.account.management.errorhandling.exceptions.ForbiddenPermissionsException;
 import uk.gov.hmcts.reform.pip.account.management.errorhandling.exceptions.NotFoundException;
+
 import java.time.LocalDateTime;
 import javax.validation.ConstraintViolationException;
 

--- a/src/main/java/uk/gov/hmcts/reform/pip/account/management/errorhandling/exceptions/ForbiddenPermissionsException.java
+++ b/src/main/java/uk/gov/hmcts/reform/pip/account/management/errorhandling/exceptions/ForbiddenPermissionsException.java
@@ -1,0 +1,18 @@
+package uk.gov.hmcts.reform.pip.account.management.errorhandling.exceptions;
+
+/**
+ * Exception for a user not having correct classification level for target.
+ */
+public class ForbiddenPermissionsException extends RuntimeException {
+
+    private static final long serialVersionUID = 869436819230575103L;
+
+    /**
+     * Constructor for ForbiddenPermissionsException.
+     *
+     * @param message Error message
+     */
+    public ForbiddenPermissionsException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/pip/account/management/errorhandling/exceptions/NotFoundException.java
+++ b/src/main/java/uk/gov/hmcts/reform/pip/account/management/errorhandling/exceptions/NotFoundException.java
@@ -1,0 +1,17 @@
+package uk.gov.hmcts.reform.pip.account.management.errorhandling.exceptions;
+
+/**
+ * Custom exception which handles not found errors.
+ */
+public class NotFoundException extends RuntimeException {
+
+    private static final long serialVersionUID = -5622817523799460884L;
+
+    /**
+     * Constructor for custom NotFoundException.
+     * @param message error message.
+     */
+    public NotFoundException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/pip/account/management/errorhandling/exceptions/UserNotFoundException.java
+++ b/src/main/java/uk/gov/hmcts/reform/pip/account/management/errorhandling/exceptions/UserNotFoundException.java
@@ -1,0 +1,21 @@
+package uk.gov.hmcts.reform.pip.account.management.errorhandling.exceptions;
+
+/**
+ * Exception for a user not being found.
+ */
+public class UserNotFoundException extends NotFoundException {
+
+    private static final long serialVersionUID = -8379848393786710695L;
+
+    private static final String MESSAGE = "No user found with the %s: %s";
+
+    /**
+     * Constructor for custom UserNotFoundException.
+     *
+     * @param idType the type of id searching, whether userId or provenanceUserId.
+     * @param id the id searched for.
+     */
+    public UserNotFoundException(String idType, String id) {
+        super(String.format(MESSAGE, idType, id));
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/pip/account/management/model/ListType.java
+++ b/src/main/java/uk/gov/hmcts/reform/pip/account/management/model/ListType.java
@@ -1,5 +1,6 @@
 package uk.gov.hmcts.reform.pip.account.management.model;
 
+@SuppressWarnings("PMD.NullAssignment")
 public enum ListType {
     SJP_PUBLIC_LIST,
     SJP_PRESS_LIST(UserProvenances.PI_AAD),

--- a/src/main/java/uk/gov/hmcts/reform/pip/account/management/model/ListType.java
+++ b/src/main/java/uk/gov/hmcts/reform/pip/account/management/model/ListType.java
@@ -1,0 +1,24 @@
+package uk.gov.hmcts.reform.pip.account.management.model;
+
+public enum ListType {
+    SJP_PUBLIC_LIST,
+    SJP_PRESS_LIST(UserProvenances.PI_AAD),
+    CROWN_DAILY_LIST,
+    CROWN_FIRM_LIST,
+    CROWN_WARNED_LIST,
+    MAGS_PUBLIC_LIST,
+    MAGS_STANDARD_LIST,
+    CIVIL_DAILY_CAUSE_LIST,
+    FAMILY_DAILY_CAUSE_LIST,
+    TRIBUNAL_DAILY_CAUSE_LIST;
+
+    public final UserProvenances allowedProvenance;
+
+    ListType(UserProvenances allowedProvenance) {
+        this.allowedProvenance = allowedProvenance;
+    }
+
+    ListType() {
+        this.allowedProvenance = null;
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/pip/account/management/service/AccountService.java
+++ b/src/main/java/uk/gov/hmcts/reform/pip/account/management/service/AccountService.java
@@ -36,6 +36,7 @@ import static uk.gov.hmcts.reform.pip.model.LogBuilder.writeLog;
  */
 @Slf4j
 @Component
+@SuppressWarnings("PMD.LawOfDemeter")
 public class AccountService {
 
     private static final String FORBIDDEN_MESSAGE =

--- a/src/test/java/uk/gov/hmcts/reform/pip/account/management/controllers/AccountControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/pip/account/management/controllers/AccountControllerTest.java
@@ -21,7 +21,6 @@ import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.when;
@@ -82,12 +81,12 @@ class AccountControllerTest {
         when(accountService.isUserAuthorisedForPublication(any(), any())).thenReturn(true);
         assertEquals(
             HttpStatus.OK,
-            accountController.isUserAuthorised(UUID.randomUUID(), ListType.MAGS_PUBLIC_LIST).getStatusCode(),
+            accountController.checkUserAuthorised(UUID.randomUUID(), ListType.MAGS_PUBLIC_LIST).getStatusCode(),
             STATUS_CODE_MATCH
         );
         assertEquals(
             true,
-            accountController.isUserAuthorised(UUID.randomUUID(), ListType.MAGS_PUBLIC_LIST).getBody(),
+            accountController.checkUserAuthorised(UUID.randomUUID(), ListType.MAGS_PUBLIC_LIST).getBody(),
             "Should return boolean value"
         );
     }

--- a/src/test/java/uk/gov/hmcts/reform/pip/account/management/controllers/AccountControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/pip/account/management/controllers/AccountControllerTest.java
@@ -8,15 +8,19 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import uk.gov.hmcts.reform.pip.account.management.model.CreationEnum;
+import uk.gov.hmcts.reform.pip.account.management.model.ListType;
 import uk.gov.hmcts.reform.pip.account.management.model.PiUser;
 import uk.gov.hmcts.reform.pip.account.management.model.Subscriber;
 import uk.gov.hmcts.reform.pip.account.management.service.AccountService;
 
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.when;
 
@@ -28,6 +32,8 @@ class AccountControllerTest {
 
     @InjectMocks
     private AccountController accountController;
+
+    private static final String MESSAGES_MATCH = "Status codes should match";
 
     @Test
     void createSubscriber() {
@@ -44,7 +50,7 @@ class AccountControllerTest {
         ResponseEntity<Map<CreationEnum, List<? extends Subscriber>>> response =
             accountController.createSubscriber(subscribers);
 
-        assertEquals(HttpStatus.OK, response.getStatusCode(), "Should return an OK status code");
+        assertEquals(HttpStatus.OK, response.getStatusCode(), MESSAGES_MATCH);
         assertEquals(subscribersMap, response.getBody(), "Should return the expected subscribers map");
     }
 
@@ -63,8 +69,19 @@ class AccountControllerTest {
         ResponseEntity<Map<CreationEnum, List<?>>> response = accountController.createUsers("test", users);
 
         assertEquals(HttpStatus.CREATED, response.getStatusCode(),
-                     "Should return created status");
+                     MESSAGES_MATCH);
         assertEquals(usersMap, response.getBody(), "Should return the expected user map");
+    }
+
+    @Test
+    void testIsUserAuthorised() {
+        when(accountService.isUserAuthorisedForPublication(any(), any())).thenReturn(true);
+        assertEquals(HttpStatus.OK,
+                     accountController.isUserAuthorised(UUID.randomUUID(), ListType.MAGS_PUBLIC_LIST).getStatusCode(),
+                     MESSAGES_MATCH);
+        assertEquals(true,
+                     accountController.isUserAuthorised(UUID.randomUUID(), ListType.MAGS_PUBLIC_LIST).getBody(),
+                     "Should return boolean value");
     }
 
 }

--- a/src/test/java/uk/gov/hmcts/reform/pip/account/management/errorhandling/GlobalExceptionHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/pip/account/management/errorhandling/GlobalExceptionHandlerTest.java
@@ -22,6 +22,7 @@ class GlobalExceptionHandlerTest {
     private static final String ERROR_MESSAGE = "Exception Message";
     private static final String NOT_NULL_MESSAGE = "Exception body should not be null";
     private static final String EXCEPTION_BODY_NOT_MATCH = "Exception body doesn't match test message";
+    public static final String RESPONSE_SHOULD_CONTAIN_A_BODY = "Response should contain a body";
 
     private final GlobalExceptionHandler globalExceptionHandler = new GlobalExceptionHandler();
 
@@ -33,7 +34,7 @@ class GlobalExceptionHandlerTest {
             globalExceptionHandler.handle(jsonMappingException);
 
         assertEquals(HttpStatus.BAD_REQUEST, responseEntity.getStatusCode(), "Status code should be bad request");
-        assertNotNull(responseEntity.getBody(), "Response should contain a body");
+        assertNotNull(responseEntity.getBody(), RESPONSE_SHOULD_CONTAIN_A_BODY);
         assertEquals(ERROR_MESSAGE, responseEntity.getBody().getMessage(),
                      EXCEPTION_BODY_NOT_MATCH);
     }
@@ -46,7 +47,7 @@ class GlobalExceptionHandlerTest {
         ResponseEntity<ExceptionResponse> responseEntity = globalExceptionHandler.handle(missingRequestHeaderException);
 
         assertEquals(HttpStatus.BAD_REQUEST, responseEntity.getStatusCode(), "Status code should be bad request");
-        assertNotNull(responseEntity.getBody(), "Response should contain a body");
+        assertNotNull(responseEntity.getBody(), RESPONSE_SHOULD_CONTAIN_A_BODY);
         assertEquals("Required request header 'test' for method parameter type String is not present",
                      responseEntity.getBody().getMessage(), EXCEPTION_BODY_NOT_MATCH);
     }
@@ -70,7 +71,7 @@ class GlobalExceptionHandlerTest {
         ResponseEntity<ExceptionResponse> responseEntity = globalExceptionHandler.handle(notFoundException);
 
         assertEquals(HttpStatus.NOT_FOUND, responseEntity.getStatusCode(), "Status code should be not found");
-        assertNotNull(responseEntity.getBody(), "Response should contain a body");
+        assertNotNull(responseEntity.getBody(), RESPONSE_SHOULD_CONTAIN_A_BODY);
         assertEquals(ERROR_MESSAGE,
                      responseEntity.getBody().getMessage(), EXCEPTION_BODY_NOT_MATCH);
     }
@@ -81,7 +82,7 @@ class GlobalExceptionHandlerTest {
         ResponseEntity<ExceptionResponse> responseEntity = globalExceptionHandler.handle(forbiddenPermissionsException);
 
         assertEquals(HttpStatus.FORBIDDEN, responseEntity.getStatusCode(), "Status code should be not found");
-        assertNotNull(responseEntity.getBody(), "Response should contain a body");
+        assertNotNull(responseEntity.getBody(), RESPONSE_SHOULD_CONTAIN_A_BODY);
         assertEquals(ERROR_MESSAGE,
                      responseEntity.getBody().getMessage(), EXCEPTION_BODY_NOT_MATCH);
     }

--- a/src/test/java/uk/gov/hmcts/reform/pip/account/management/service/AccountServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/pip/account/management/service/AccountServiceTest.java
@@ -1,6 +1,7 @@
 package uk.gov.hmcts.reform.pip.account.management.service;
 
 import com.microsoft.graph.models.User;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -9,6 +10,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.hmcts.reform.pip.account.management.database.UserRepository;
 import uk.gov.hmcts.reform.pip.account.management.errorhandling.exceptions.AzureCustomException;
 import uk.gov.hmcts.reform.pip.account.management.model.CreationEnum;
+import uk.gov.hmcts.reform.pip.account.management.model.ListType;
 import uk.gov.hmcts.reform.pip.account.management.model.PiUser;
 import uk.gov.hmcts.reform.pip.account.management.model.Roles;
 import uk.gov.hmcts.reform.pip.account.management.model.Subscriber;
@@ -18,6 +20,7 @@ import uk.gov.hmcts.reform.pip.account.management.model.errored.ErroredSubscribe
 
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
@@ -57,6 +60,17 @@ class AccountServiceTest {
     private static final String VALIDATION_MESSAGE = "Validation Message";
     private static final String EMAIL_VALIDATION_MESSAGE = "Subscriber should have expected email";
     private static final String ERRORED_ACCOUNTS_VALIDATION_MESSAGE = "Should contain ERRORED_ACCOUNTS key";
+    private static final UUID VALID_USER_ID = UUID.randomUUID();
+
+    private final PiUser piUser = new PiUser();
+
+    @BeforeEach
+    void setup() {
+        piUser.setUserId(VALID_USER_ID);
+        piUser.setUserProvenance(UserProvenances.PI_AAD);
+        piUser.setProvenanceUserId(ID);
+        when(userRepository.findByUserId(VALID_USER_ID)).thenReturn(Optional.of(piUser));
+    }
 
     @Test
     void testSubscriberCreated() throws AzureCustomException {
@@ -233,5 +247,13 @@ class AccountServiceTest {
                      "Returned maps should match created and errored"
         );
     }
+
+    @Test
+    void testIsUserAuthorisedForPublicationReturnsTrue() {
+        assertTrue(accountService.isUserAuthorisedForPublication(VALID_USER_ID, ListType.SJP_PRESS_LIST),
+                   "User from PI_AAD should return true for allowed list type");
+    }
+    //TODO write the other tests for the null list type value, user with diff prov, and try merge 1051 asap to get
+    // the error handling from it
 
 }

--- a/src/test/java/uk/gov/hmcts/reform/pip/account/management/service/AccountServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/pip/account/management/service/AccountServiceTest.java
@@ -39,6 +39,7 @@ import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
+@SuppressWarnings("PMD.TooManyMethods")
 class AccountServiceTest {
 
     @Mock


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/PUB-1154


### Change description ###
### API 
added api that takes in a user id and list type, and returns a 200 and true if the user has permission to see the list.

This comes from the need for splitting lists with a Classified level of sensitivity, only users that have the same provenance where the list came from can see the classified lists, most list types will have a public or private level so values are set to null but those that will be classified list the allowed provenance as part of the list type, 
if you do not have permission to view a 403 will be returned


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
