### PR TITLE
PUB-1400 Delete media id

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/pip/account/management/service/MediaApplicationService.java
+++ b/src/main/java/uk/gov/hmcts/reform/pip/account/management/service/MediaApplicationService.java
@@ -20,6 +20,7 @@ import java.util.stream.Collectors;
 
 @Slf4j
 @Service
+@SuppressWarnings("PMD.LawOfDemeter")
 public class MediaApplicationService {
 
     private final MediaApplicationRepository mediaApplicationRepository;
@@ -100,6 +101,7 @@ public class MediaApplicationService {
 
     /**
      * Update an application by fetching the application.
+     * If the status has been updated to Approved or Rejected then also delete the stored image.
      *
      * @param id The id of the application to update
      * @param status The status to update the application with
@@ -111,6 +113,10 @@ public class MediaApplicationService {
 
         applicationToUpdate.setStatus(status);
         applicationToUpdate.setStatusDate(LocalDateTime.now());
+
+        if (MediaApplicationStatus.APPROVED.equals(status) || MediaApplicationStatus.REJECTED.equals(status)) {
+            azureBlobService.deleteBlob(applicationToUpdate.getImage());
+        }
 
         return mediaApplicationRepository.save(applicationToUpdate);
     }

--- a/src/test/java/uk/gov/hmcts/reform/pip/account/management/service/MediaApplicationServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/pip/account/management/service/MediaApplicationServiceTest.java
@@ -151,7 +151,7 @@ class MediaApplicationServiceTest {
     }
 
     @Test
-    void testUpdateApplication() {
+    void testUpdateApplicationApproved() {
         when(mediaApplicationRepository.findById(TEST_ID)).thenReturn(Optional.ofNullable(
             mediaApplicationExample));
 
@@ -162,6 +162,42 @@ class MediaApplicationServiceTest {
             .updateApplication(TEST_ID, MediaApplicationStatus.APPROVED);
 
         assertEquals(UPDATED_STATUS, returnedApplication.getStatus(), "Application status was not updated");
+
+        verify(azureBlobService, times(1)).deleteBlob(BLOB_UUID);
+    }
+
+    @Test
+    void testUpdateApplicationRejected() {
+        when(mediaApplicationRepository.findById(TEST_ID)).thenReturn(Optional.ofNullable(
+            mediaApplicationExample));
+
+        when(mediaApplicationRepository.save(mediaApplicationExample))
+            .thenReturn(mediaApplicationExample);
+
+        MediaApplication returnedApplication = mediaApplicationService
+            .updateApplication(TEST_ID, MediaApplicationStatus.REJECTED);
+
+        assertEquals(MediaApplicationStatus.REJECTED, returnedApplication.getStatus(),
+                     "Application status was not updated");
+
+        verify(azureBlobService, times(1)).deleteBlob(BLOB_UUID);
+    }
+
+    @Test
+    void testUpdateApplicationPending() {
+        when(mediaApplicationRepository.findById(TEST_ID)).thenReturn(Optional.ofNullable(
+            mediaApplicationExample));
+
+        when(mediaApplicationRepository.save(mediaApplicationExample))
+            .thenReturn(mediaApplicationExample);
+
+        MediaApplication returnedApplication = mediaApplicationService
+            .updateApplication(TEST_ID, MediaApplicationStatus.PENDING);
+
+        assertEquals(MediaApplicationStatus.PENDING, returnedApplication.getStatus(),
+                     "Application status was not updated");
+
+        verify(azureBlobService, times(0)).deleteBlob(BLOB_UUID);
     }
 
     @Test


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/PUB-1400

### Change description ###

This change deletes the uploaded media ID in the blob store when the applications status is updated to either approved or rejected.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
