### PR TITLE
PUB-1213 Handle AAD admin and IDAM user account sign in verification

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -173,7 +173,7 @@ dependencies {
   implementation group: 'com.github.hmcts', name: 'pip-data-models', version: '1.1.1', {
     exclude group: 'org.springframework.boot', module: 'spring-boot-starter-data-jpa'
   }
-  implementation group: 'org.postgresql', name: 'postgresql', version: '42.3.3'
+  implementation group: 'org.postgresql', name: 'postgresql', version: '42.4.1'
   implementation 'com.azure.spring:spring-cloud-azure-starter-active-directory:4.0.0'
   implementation group: 'org.springframework.boot', name: 'spring-boot-starter-oauth2-resource-server'
   implementation group: 'org.springframework.boot', name:'spring-boot-starter-webflux'

--- a/src/main/java/uk/gov/hmcts/reform/pip/account/management/config/flyway/FlywayNoOpStrategy.java
+++ b/src/main/java/uk/gov/hmcts/reform/pip/account/management/config/flyway/FlywayNoOpStrategy.java
@@ -19,5 +19,4 @@ public class FlywayNoOpStrategy implements FlywayMigrationStrategy {
                 throw new PendingMigrationScriptException(info.getScript());
             });
     }
-
 }

--- a/src/main/java/uk/gov/hmcts/reform/pip/account/management/database/UserRepository.java
+++ b/src/main/java/uk/gov/hmcts/reform/pip/account/management/database/UserRepository.java
@@ -21,5 +21,13 @@ public interface UserRepository extends JpaRepository<PiUser, Long> {
         + " * :daysAgo AND roles = 'VERIFIED'", nativeQuery = true)
     List<PiUser> findVerifiedUsersByLastVerifiedDate(@Param("daysAgo") int daysSinceLastVerified);
 
+    @Query(value = "SELECT * FROM pi_user WHERE CAST(last_signed_in_date AS DATE) = CURRENT_DATE - (interval '1' day)"
+        + " * :daysAgo AND roles <> 'VERIFIED' AND userProvenance = 'PI_AAD'", nativeQuery = true)
+    List<PiUser> findAadAdminUsersByLastSignedInDate(@Param("daysAgo") int daysSinceLastSignedIn);
+
+    @Query(value = "SELECT * FROM pi_user WHERE CAST(last_signed_in_date AS DATE) = CURRENT_DATE - (interval '1' day)"
+        + " * :daysAgo AND (userProvenance = 'CFT_IDAM' OR userProvenance = 'CRIME_IDAM')", nativeQuery = true)
+    List<PiUser> findIdamUsersByLastSignedInDate(@Param("daysAgo") int daysSinceLastSignedIn);
+
     Optional<PiUser> findByEmail(String email);
 }

--- a/src/main/java/uk/gov/hmcts/reform/pip/account/management/database/UserRepository.java
+++ b/src/main/java/uk/gov/hmcts/reform/pip/account/management/database/UserRepository.java
@@ -22,11 +22,11 @@ public interface UserRepository extends JpaRepository<PiUser, Long> {
     List<PiUser> findVerifiedUsersByLastVerifiedDate(@Param("daysAgo") int daysSinceLastVerified);
 
     @Query(value = "SELECT * FROM pi_user WHERE CAST(last_signed_in_date AS DATE) = CURRENT_DATE - (interval '1' day)"
-        + " * :daysAgo AND roles <> 'VERIFIED' AND userProvenance = 'PI_AAD'", nativeQuery = true)
+        + " * :daysAgo AND roles <> 'VERIFIED' AND user_provenance = 'PI_AAD'", nativeQuery = true)
     List<PiUser> findAadAdminUsersByLastSignedInDate(@Param("daysAgo") int daysSinceLastSignedIn);
 
     @Query(value = "SELECT * FROM pi_user WHERE CAST(last_signed_in_date AS DATE) = CURRENT_DATE - (interval '1' day)"
-        + " * :daysAgo AND (userProvenance = 'CFT_IDAM' OR userProvenance = 'CRIME_IDAM')", nativeQuery = true)
+        + " * :daysAgo AND (user_provenance = 'CFT_IDAM' OR user_provenance = 'CRIME_IDAM')", nativeQuery = true)
     List<PiUser> findIdamUsersByLastSignedInDate(@Param("daysAgo") int daysSinceLastSignedIn);
 
     Optional<PiUser> findByEmail(String email);

--- a/src/main/java/uk/gov/hmcts/reform/pip/account/management/model/PiUser.java
+++ b/src/main/java/uk/gov/hmcts/reform/pip/account/management/model/PiUser.java
@@ -79,4 +79,9 @@ public class PiUser {
      * The timestamp of when the user was last verified.
      */
     private LocalDateTime lastVerifiedDate;
+
+    /**
+     * The timestamp when the user was last signed in.
+     */
+    private LocalDateTime lastSignedInDate;
 }

--- a/src/main/java/uk/gov/hmcts/reform/pip/account/management/model/errored/ErroredPiUser.java
+++ b/src/main/java/uk/gov/hmcts/reform/pip/account/management/model/errored/ErroredPiUser.java
@@ -30,6 +30,7 @@ public class ErroredPiUser extends PiUser {
               user.getEmail(),
               user.getRoles(),
               user.getCreatedDate(),
-              user.getLastVerifiedDate());
+              user.getLastVerifiedDate(),
+              user.getLastSignedInDate());
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/pip/account/management/service/AccountService.java
+++ b/src/main/java/uk/gov/hmcts/reform/pip/account/management/service/AccountService.java
@@ -323,12 +323,15 @@ public class AccountService {
             if (isAadAccount) {
                 azureUserService.deleteUser(userToDelete.getProvenanceUserId());
             }
-            log.info(subscriptionService.sendSubscriptionDeletionRequest(userToDelete.getUserId().toString()));
+            log.info(writeLog(
+                subscriptionService.sendSubscriptionDeletionRequest(userToDelete.getUserId().toString()))
+            );
             userRepository.delete(userToDelete);
             returnMessage = String.format("User with ID %s has been deleted", userToDelete.getUserId());
         } catch (AzureCustomException ex) {
-            log.error("Error when deleting an account from azure with Provenance user id: %s and error: %s",
-                      userToDelete.getProvenanceUserId(), ex.getMessage());
+            log.error(writeLog(String.format("Error when deleting an account from azure with Provenance user id: "
+                                                 + "%s and error: %s",
+                                             userToDelete.getProvenanceUserId(), ex.getMessage())));
         }
         return returnMessage;
     }

--- a/src/main/java/uk/gov/hmcts/reform/pip/account/management/service/AccountVerificationService.java
+++ b/src/main/java/uk/gov/hmcts/reform/pip/account/management/service/AccountVerificationService.java
@@ -12,6 +12,7 @@ import java.util.Collection;
 import java.util.stream.Stream;
 
 import static uk.gov.hmcts.reform.pip.account.management.model.UserProvenances.PI_AAD;
+import static uk.gov.hmcts.reform.pip.model.LogBuilder.writeLog;
 
 @Slf4j
 @Service
@@ -71,7 +72,7 @@ public class AccountVerificationService {
                     azureUserService.getUser(user.getEmail()).givenName
                 ));
             } catch (AzureCustomException ex) {
-                log.error("Error when getting user from azure: %s", ex.getMessage());
+                log.error(writeLog("Error when getting user from azure: " + ex.getMessage()));
             }
         });
     }
@@ -87,7 +88,7 @@ public class AccountVerificationService {
                 userRepository.findAadAdminUsersByLastSignedInDate(aadAdminAccountSignInNotificationDays),
                 userRepository.findIdamUsersByLastSignedInDate(idamAccountSignInNotificationDays))
             .flatMap(Collection::stream)
-            .forEach(user -> log.info("Remind user to sign in: " + user.getEmail()));
+            .forEach(user -> log.info(writeLog("Remind user to sign in: " + user.getEmail())));
     }
 
     /**
@@ -102,8 +103,8 @@ public class AccountVerificationService {
                 userRepository.findIdamUsersByLastSignedInDate(idamAccountDeletionDays))
             .flatMap(Collection::stream)
             .forEach(
-                user -> log.info(accountService.deleteAccount(user.getEmail(),
-                                                              PI_AAD.equals(user.getUserProvenance())))
+                user -> log.info(writeLog(accountService.deleteAccount(user.getEmail(),
+                                                              PI_AAD.equals(user.getUserProvenance()))))
             );
     }
 }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -86,7 +86,7 @@ azure:
 
 cron:
   media-application-reporting: "59 23 */30 * * *"
-  media-account-verification-check: "00 09 * * * *"
+  account-verification-check: "00 09 * * * *"
 
 dbMigration:
   runOnStartup: ${RUN_DB_MIGRATION_ON_STARTUP:true}
@@ -94,3 +94,7 @@ dbMigration:
 verification:
   media-account-verification-email-days: 350
   media-account-deletion-days: 365
+  aad-admin-account-sign-in-notification-days: 76
+  aad-admin-account-deletion-days: 90
+  idam-account-sign-in-notification-days: 118
+  idam-account-deletion-days: 128

--- a/src/main/resources/db/migration/V1.2__pi_user_last_sign_in_date_set.sql
+++ b/src/main/resources/db/migration/V1.2__pi_user_last_sign_in_date_set.sql
@@ -1,0 +1,16 @@
+--
+-- Add new column for last sign in date if it doesn't exist
+--
+ALTER TABLE pi_user
+    ADD COLUMN IF NOT EXISTS last_sign_in_date timestamp;
+
+--
+-- Set the last_sign_in_date to the created_date for:
+-- - AAD admin users
+-- - All IDAM users
+--
+UPDATE pi_user
+SET last_sign_in_date = created_date
+WHERE (user_provenance = 'PI_AAD' AND roles <> 'VERIFIED')
+   OR user_provenance = 'CFT_IDAM'
+   OR user_provenance = 'CRIME_IDAM';

--- a/src/main/resources/db/migration/V1.2__pi_user_last_sign_in_date_set.sql
+++ b/src/main/resources/db/migration/V1.2__pi_user_last_sign_in_date_set.sql
@@ -2,7 +2,7 @@
 -- Add new column for last sign in date if it doesn't exist
 --
 ALTER TABLE pi_user
-    ADD COLUMN IF NOT EXISTS last_sign_in_date timestamp;
+    ADD COLUMN IF NOT EXISTS last_signed_in_date timestamp;
 
 --
 -- Set the last_sign_in_date to the created_date for:
@@ -10,7 +10,7 @@ ALTER TABLE pi_user
 -- - All IDAM users
 --
 UPDATE pi_user
-SET last_sign_in_date = created_date
+SET last_signed_in_date = created_date
 WHERE (user_provenance = 'PI_AAD' AND roles <> 'VERIFIED')
    OR user_provenance = 'CFT_IDAM'
    OR user_provenance = 'CRIME_IDAM';

--- a/src/test/java/uk/gov/hmcts/reform/pip/account/management/service/AccountVerificationServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/pip/account/management/service/AccountVerificationServiceTest.java
@@ -203,7 +203,7 @@ class AccountVerificationServiceTest {
                 .hasSize(1)
                 .first()
                 .asString()
-                .startsWith("Error when getting user from azure");
+                .contains("Error when getting user from azure");
         }
 
         verifyNoInteractions(accountService);

--- a/src/test/java/uk/gov/hmcts/reform/pip/account/management/service/AccountVerificationServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/pip/account/management/service/AccountVerificationServiceTest.java
@@ -1,0 +1,212 @@
+package uk.gov.hmcts.reform.pip.account.management.service;
+
+import com.microsoft.graph.models.User;
+import nl.altindag.log.LogCaptor;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import uk.gov.hmcts.reform.pip.account.management.database.UserRepository;
+import uk.gov.hmcts.reform.pip.account.management.errorhandling.exceptions.AzureCustomException;
+import uk.gov.hmcts.reform.pip.account.management.model.PiUser;
+import uk.gov.hmcts.reform.pip.account.management.model.Roles;
+import uk.gov.hmcts.reform.pip.account.management.model.UserProvenances;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.anyInt;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class AccountVerificationServiceTest {
+    private static final String MEDIA_USER_EMAIL = "media@test.com";
+    private static final String AAD_ADMIN_USER_EMAIL = "aad_admin@test.com";
+    private static final String CFT_IDAM_USER_EMAIL = "cft_idam@test.com";
+    private static final String CRIME_IDAM_USER_EMAIL = "crime_idam@test.com";
+    private static final String AZURE_MEDIA_USER_NAME = "MediaUserName";
+
+    private static final PiUser MEDIA_USER = new PiUser(UUID.randomUUID(), UserProvenances.PI_AAD,
+                                                        "1", MEDIA_USER_EMAIL, Roles.VERIFIED,
+                                                        null, null, null);
+    private static final PiUser AAD_ADMIN_USER = new PiUser(UUID.randomUUID(), UserProvenances.PI_AAD,
+                                                            "2", AAD_ADMIN_USER_EMAIL, Roles.INTERNAL_SUPER_ADMIN_CTSC,
+                                                            null, null, null);
+    private static final PiUser CFT_IDAM_USER = new PiUser(UUID.randomUUID(), UserProvenances.CFT_IDAM,
+                                                           "3", CFT_IDAM_USER_EMAIL, Roles.INTERNAL_ADMIN_CTSC,
+                                                           null, null, null);
+    private static final PiUser CRIME_IDAM_USER = new PiUser(UUID.randomUUID(), UserProvenances.CFT_IDAM,
+                                                             "4", CRIME_IDAM_USER_EMAIL, Roles.INTERNAL_ADMIN_CTSC,
+                                                             null, null, null);
+
+    private static User azureMediaUser = new User();
+
+    @Mock
+    UserRepository userRepository;
+
+    @Mock
+    AzureUserService azureUserService;
+
+    @Mock
+    AccountService accountService;
+
+    @Mock
+    PublicationService publicationService;
+
+    @InjectMocks
+    private AccountVerificationService accountVerificationService;
+
+    @BeforeAll
+    static void setup() {
+        azureMediaUser.givenName = AZURE_MEDIA_USER_NAME;
+    }
+
+    @Test
+    void testNoAccountDeletionAndNotification() {
+        when(userRepository.findVerifiedUsersByLastVerifiedDate(anyInt()))
+            .thenReturn(Collections.emptyList());
+        when(userRepository.findAadAdminUsersByLastSignedInDate(anyInt()))
+            .thenReturn(Collections.emptyList());
+        when(userRepository.findIdamUsersByLastSignedInDate(anyInt()))
+            .thenReturn(Collections.emptyList());
+
+        accountVerificationService.processEligibleUsersForVerification();
+
+        verifyNoInteractions(accountService);
+        verifyNoInteractions(publicationService);
+        verifyNoInteractions(azureUserService);
+    }
+
+    @Test
+    void testAccountDeletionOfMediaUserOnly() {
+        when(userRepository.findVerifiedUsersByLastVerifiedDate(anyInt()))
+            .thenReturn(Collections.singletonList(MEDIA_USER))
+            .thenReturn(Collections.emptyList());
+        when(userRepository.findAadAdminUsersByLastSignedInDate(anyInt()))
+            .thenReturn(Collections.emptyList());
+        when(userRepository.findIdamUsersByLastSignedInDate(anyInt()))
+            .thenReturn(Collections.emptyList());
+
+        accountVerificationService.processEligibleUsersForVerification();
+
+        verify(accountService).deleteAccount(MEDIA_USER_EMAIL, true);
+        verifyNoMoreInteractions(accountService);
+        verifyNoInteractions(publicationService);
+        verifyNoInteractions(azureUserService);
+    }
+
+    @Test
+    void testAccountDeletionOfAadAdminAndIdamUsersOnly() {
+        when(userRepository.findVerifiedUsersByLastVerifiedDate(anyInt()))
+            .thenReturn(Collections.emptyList());
+        when(userRepository.findAadAdminUsersByLastSignedInDate(anyInt()))
+            .thenReturn(Collections.singletonList(AAD_ADMIN_USER))
+            .thenReturn(Collections.emptyList());
+        when(userRepository.findIdamUsersByLastSignedInDate(anyInt()))
+            .thenReturn(Collections.singletonList(CRIME_IDAM_USER))
+            .thenReturn(Collections.emptyList());
+
+        accountVerificationService.processEligibleUsersForVerification();
+
+        verify(accountService).deleteAccount(AAD_ADMIN_USER_EMAIL, true);
+        verify(accountService).deleteAccount(CRIME_IDAM_USER_EMAIL, false);
+        verifyNoMoreInteractions(accountService);
+        verifyNoInteractions(publicationService);
+        verifyNoInteractions(azureUserService);
+    }
+
+    @Test
+    void testAccountDeletionOfAllUsers() {
+        when(userRepository.findVerifiedUsersByLastVerifiedDate(anyInt()))
+            .thenReturn(Collections.singletonList(MEDIA_USER))
+            .thenReturn(Collections.emptyList());
+        when(userRepository.findAadAdminUsersByLastSignedInDate(anyInt()))
+            .thenReturn(Collections.singletonList(AAD_ADMIN_USER))
+            .thenReturn(Collections.emptyList());
+        when(userRepository.findIdamUsersByLastSignedInDate(anyInt()))
+            .thenReturn(Arrays.asList(CFT_IDAM_USER, CRIME_IDAM_USER))
+            .thenReturn(Collections.emptyList());
+
+        accountVerificationService.processEligibleUsersForVerification();
+
+        verify(accountService).deleteAccount(MEDIA_USER_EMAIL, true);
+        verify(accountService).deleteAccount(AAD_ADMIN_USER_EMAIL, true);
+        verify(accountService).deleteAccount(CFT_IDAM_USER_EMAIL, false);
+        verify(accountService).deleteAccount(CRIME_IDAM_USER_EMAIL, false);
+        verifyNoInteractions(publicationService);
+        verifyNoInteractions(azureUserService);
+    }
+
+    @Test
+    void testAccountDeletionOfCftIdamUserAndNotificationOfMediaUser() throws AzureCustomException {
+        when(userRepository.findVerifiedUsersByLastVerifiedDate(anyInt()))
+            .thenReturn(Collections.emptyList())
+            .thenReturn(Collections.singletonList(MEDIA_USER));
+        when(userRepository.findAadAdminUsersByLastSignedInDate(anyInt()))
+            .thenReturn(Collections.emptyList());
+        when(userRepository.findIdamUsersByLastSignedInDate(anyInt()))
+            .thenReturn(Collections.singletonList(CFT_IDAM_USER))
+            .thenReturn(Collections.emptyList());
+        when(azureUserService.getUser(MEDIA_USER_EMAIL)).thenReturn(azureMediaUser);
+
+        accountVerificationService.processEligibleUsersForVerification();
+
+        verify(accountService).deleteAccount(CFT_IDAM_USER_EMAIL, false);
+        verifyNoMoreInteractions(accountService);
+        verify(publicationService).sendAccountVerificationEmail(MEDIA_USER_EMAIL, AZURE_MEDIA_USER_NAME);
+    }
+
+    @Test
+    void testNotificationOfAllUsers() throws AzureCustomException {
+        when(userRepository.findVerifiedUsersByLastVerifiedDate(anyInt()))
+            .thenReturn(Collections.emptyList())
+            .thenReturn(Collections.singletonList(MEDIA_USER));
+        when(userRepository.findAadAdminUsersByLastSignedInDate(anyInt()))
+            .thenReturn(Collections.emptyList())
+            .thenReturn(Collections.singletonList(AAD_ADMIN_USER));
+        when(userRepository.findIdamUsersByLastSignedInDate(anyInt()))
+            .thenReturn(Collections.emptyList())
+            .thenReturn(Arrays.asList(CFT_IDAM_USER, CRIME_IDAM_USER));
+        when(azureUserService.getUser(MEDIA_USER_EMAIL)).thenReturn(azureMediaUser);
+
+        accountVerificationService.processEligibleUsersForVerification();
+
+        verifyNoInteractions(accountService);
+        verify(publicationService).sendAccountVerificationEmail(MEDIA_USER_EMAIL, AZURE_MEDIA_USER_NAME);
+    }
+
+    @Test
+    void testMediaUserNotificationWithAzureException() throws AzureCustomException {
+        when(userRepository.findVerifiedUsersByLastVerifiedDate(anyInt()))
+            .thenReturn(Collections.emptyList())
+            .thenReturn(Collections.singletonList(MEDIA_USER));
+        when(userRepository.findAadAdminUsersByLastSignedInDate(anyInt()))
+            .thenReturn(Collections.emptyList());
+        when(userRepository.findIdamUsersByLastSignedInDate(anyInt()))
+            .thenReturn(Collections.emptyList());
+        when(azureUserService.getUser(MEDIA_USER_EMAIL)).thenThrow(new AzureCustomException("error"));
+
+        try (LogCaptor logCaptor = LogCaptor.forClass(AccountVerificationService.class)) {
+            accountVerificationService.processEligibleUsersForVerification();
+            assertThat(logCaptor.getErrorLogs())
+                .as("Incorrect error message")
+                .hasSize(1)
+                .first()
+                .asString()
+                .startsWith("Error when getting user from azure");
+        }
+
+        verifyNoInteractions(accountService);
+        verifyNoInteractions(publicationService);
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/pip/account/management/service/SchedulerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/pip/account/management/service/SchedulerTest.java
@@ -37,6 +37,6 @@ class SchedulerTest {
     void testSchedulerAccountVerificationEmailRuns() {
         await().atMost(Duration.ONE_MINUTE).untilAsserted(() ->
             verify(accountVerificationService, times(1))
-                .processEligibleMediaUsersForVerification());
+                .processEligibleUsersForVerification());
     }
 }

--- a/src/test/resources/application-test.yaml
+++ b/src/test/resources/application-test.yaml
@@ -4,7 +4,7 @@ service-to-service:
 
 cron:
   media-application-reporting: "*/10 * * * * *"
-  media-account-verification-check: "*/10 * * * * *"
+  account-verification-check: "*/10 * * * * *"
 
 dbMigration:
   runOnStartup: true


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/PUB-1213

### Change description ###

Handle AAD admin and IDAM user account sign in verification:
- Delete account if not signed in for 90 days (for AAD admin users) or 128 days (for IDAM users).
- Sending of notification email is not yet implemented in this PR.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
