### PR TITLE
PUB-1495 Add new user provenance and roles for third party users

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/pip/account/management/model/ListType.java
+++ b/src/main/java/uk/gov/hmcts/reform/pip/account/management/model/ListType.java
@@ -1,23 +1,30 @@
 package uk.gov.hmcts.reform.pip.account.management.model;
 
-@SuppressWarnings("PMD.NullAssignment")
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.List;
+
+import static uk.gov.hmcts.reform.pip.account.management.model.Roles.ALL_VERIFIED_THIRD_PARTY_CFT_ROLES;
+import static uk.gov.hmcts.reform.pip.account.management.model.Roles.ALL_VERIFIED_THIRD_PARTY_CRIME_ROLES;
+import static uk.gov.hmcts.reform.pip.account.management.model.Roles.ALL_VERIFIED_THIRD_PARTY_PRESS_ROLES;
+
+@AllArgsConstructor
+@Getter
 public enum ListType {
-    SJP_PUBLIC_LIST(UserProvenances.PI_AAD),
-    SJP_PRESS_LIST(UserProvenances.PI_AAD),
-    CROWN_DAILY_LIST(UserProvenances.CRIME_IDAM),
-    CROWN_FIRM_LIST(UserProvenances.CRIME_IDAM),
-    CROWN_WARNED_LIST(UserProvenances.CRIME_IDAM),
-    MAGS_PUBLIC_LIST(UserProvenances.CRIME_IDAM),
-    MAGS_STANDARD_LIST(UserProvenances.CRIME_IDAM),
-    CIVIL_DAILY_CAUSE_LIST(UserProvenances.CFT_IDAM),
-    FAMILY_DAILY_CAUSE_LIST(UserProvenances.CFT_IDAM),
-    CIVIL_AND_FAMILY_DAILY_CAUSE_LIST(UserProvenances.CFT_IDAM),
-    COP_DAILY_CAUSE_LIST(UserProvenances.CFT_IDAM),
-    SSCS_DAILY_LIST(UserProvenances.CFT_IDAM);
+    SJP_PUBLIC_LIST(UserProvenances.PI_AAD, ALL_VERIFIED_THIRD_PARTY_PRESS_ROLES),
+    SJP_PRESS_LIST(UserProvenances.PI_AAD, ALL_VERIFIED_THIRD_PARTY_PRESS_ROLES),
+    CROWN_DAILY_LIST(UserProvenances.CRIME_IDAM, ALL_VERIFIED_THIRD_PARTY_CRIME_ROLES),
+    CROWN_FIRM_LIST(UserProvenances.CRIME_IDAM, ALL_VERIFIED_THIRD_PARTY_CRIME_ROLES),
+    CROWN_WARNED_LIST(UserProvenances.CRIME_IDAM, ALL_VERIFIED_THIRD_PARTY_CRIME_ROLES),
+    MAGS_PUBLIC_LIST(UserProvenances.CRIME_IDAM, ALL_VERIFIED_THIRD_PARTY_CRIME_ROLES),
+    MAGS_STANDARD_LIST(UserProvenances.CRIME_IDAM, ALL_VERIFIED_THIRD_PARTY_CRIME_ROLES),
+    CIVIL_DAILY_CAUSE_LIST(UserProvenances.CFT_IDAM, ALL_VERIFIED_THIRD_PARTY_CFT_ROLES),
+    FAMILY_DAILY_CAUSE_LIST(UserProvenances.CFT_IDAM, ALL_VERIFIED_THIRD_PARTY_CFT_ROLES),
+    CIVIL_AND_FAMILY_DAILY_CAUSE_LIST(UserProvenances.CFT_IDAM, ALL_VERIFIED_THIRD_PARTY_CFT_ROLES),
+    COP_DAILY_CAUSE_LIST(UserProvenances.CFT_IDAM, ALL_VERIFIED_THIRD_PARTY_CFT_ROLES),
+    SSCS_DAILY_LIST(UserProvenances.CFT_IDAM, ALL_VERIFIED_THIRD_PARTY_CFT_ROLES);
 
-    public final UserProvenances allowedProvenance;
-
-    ListType(UserProvenances allowedProvenance) {
-        this.allowedProvenance = allowedProvenance;
-    }
+    private final UserProvenances allowedProvenance;
+    private final List<Roles> allowedThirdPartyRoles;
 }

--- a/src/main/java/uk/gov/hmcts/reform/pip/account/management/model/Roles.java
+++ b/src/main/java/uk/gov/hmcts/reform/pip/account/management/model/Roles.java
@@ -1,8 +1,14 @@
 package uk.gov.hmcts.reform.pip.account.management.model;
 
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
 /**
  * Enum of the roles allowed for users of P&I, verified are media members, Internal are different levels of admin,
- * and Technical are consumers of our service such as Courtel.
+ * and the third party ones are consumers of P&I service such as Courtel.
  */
 public enum Roles {
     VERIFIED,
@@ -10,5 +16,48 @@ public enum Roles {
     INTERNAL_SUPER_ADMIN_LOCAL,
     INTERNAL_ADMIN_CTSC,
     INTERNAL_ADMIN_LOCAL,
-    TECHNICAL
+    GENERAL_THIRD_PARTY,
+    VERIFIED_THIRD_PARTY_CRIME,
+    VERIFIED_THIRD_PARTY_CFT,
+    VERIFIED_THIRD_PARTY_PRESS,
+    VERIFIED_THIRD_PARTY_CRIME_CFT,
+    VERIFIED_THIRD_PARTY_CRIME_PRESS,
+    VERIFIED_THIRD_PARTY_CFT_PRESS,
+    VERIFIED_THIRD_PARTY_ALL;
+
+    static final List<Roles> ALL_VERIFIED_THIRD_PARTY_CRIME_ROLES = List.of(
+        VERIFIED_THIRD_PARTY_CRIME,
+        VERIFIED_THIRD_PARTY_CRIME_CFT,
+        VERIFIED_THIRD_PARTY_CRIME_PRESS,
+        VERIFIED_THIRD_PARTY_ALL
+    );
+
+    static final List<Roles> ALL_VERIFIED_THIRD_PARTY_CFT_ROLES = List.of(
+        VERIFIED_THIRD_PARTY_CFT,
+        VERIFIED_THIRD_PARTY_CRIME_CFT,
+        VERIFIED_THIRD_PARTY_CFT_PRESS,
+        VERIFIED_THIRD_PARTY_ALL
+    );
+
+    static final List<Roles> ALL_VERIFIED_THIRD_PARTY_PRESS_ROLES = List.of(
+        VERIFIED_THIRD_PARTY_PRESS,
+        VERIFIED_THIRD_PARTY_CRIME_PRESS,
+        VERIFIED_THIRD_PARTY_CFT_PRESS,
+        VERIFIED_THIRD_PARTY_ALL
+    );
+
+    public static final List<Roles> ALL_THIRD_PARTY_ROLES = Stream.of(
+            ALL_VERIFIED_THIRD_PARTY_CRIME_ROLES,
+            ALL_VERIFIED_THIRD_PARTY_CFT_ROLES,
+            ALL_VERIFIED_THIRD_PARTY_PRESS_ROLES,
+            Collections.singletonList(GENERAL_THIRD_PARTY))
+        .flatMap(Collection::stream)
+        .distinct()
+        .collect(Collectors.toList());
+
+    public static final List<Roles> ALL_VERIFIED_ROLES = Stream.of(
+            ALL_THIRD_PARTY_ROLES,
+            Collections.singletonList(VERIFIED))
+        .flatMap(Collection::stream)
+        .collect(Collectors.toList());
 }

--- a/src/main/java/uk/gov/hmcts/reform/pip/account/management/model/UserProvenances.java
+++ b/src/main/java/uk/gov/hmcts/reform/pip/account/management/model/UserProvenances.java
@@ -7,5 +7,6 @@ package uk.gov.hmcts.reform.pip.account.management.model;
 public enum UserProvenances {
     CFT_IDAM,
     CRIME_IDAM,
-    PI_AAD
+    PI_AAD,
+    THIRD_PARTY
 }

--- a/src/main/java/uk/gov/hmcts/reform/pip/account/management/service/SensitivityService.java
+++ b/src/main/java/uk/gov/hmcts/reform/pip/account/management/service/SensitivityService.java
@@ -5,14 +5,15 @@ import uk.gov.hmcts.reform.pip.account.management.model.ListType;
 import uk.gov.hmcts.reform.pip.account.management.model.PiUser;
 import uk.gov.hmcts.reform.pip.account.management.model.Roles;
 import uk.gov.hmcts.reform.pip.account.management.model.Sensitivity;
+import uk.gov.hmcts.reform.pip.account.management.model.UserProvenances;
 
+import static uk.gov.hmcts.reform.pip.account.management.model.Roles.ALL_VERIFIED_ROLES;
 
 /**
  * This class handles the checking whether a user has permission to see a publication.
  */
 @Component
 public class SensitivityService {
-
     /**
      * Checks the sensitivity / list type and user, to determine if they have permission to see the publication.
      * @param user The user to check permissions for.
@@ -26,23 +27,18 @@ public class SensitivityService {
                 return true;
             }
             case PRIVATE: {
-                if (user.getRoles().equals(Roles.VERIFIED)) {
-                    return true;
-                }
-                break;
+                return ALL_VERIFIED_ROLES.contains(user.getRoles());
             }
             case CLASSIFIED: {
-                if (user.getRoles().equals(Roles.VERIFIED)
-                    && user.getUserProvenance().equals(listType.allowedProvenance)) {
-                    return true;
-                }
-                break;
+                return user.getRoles().equals(Roles.VERIFIED)
+                        && user.getUserProvenance().equals(listType.getAllowedProvenance())
+                    || user.getUserProvenance().equals(UserProvenances.THIRD_PARTY)
+                        && listType.getAllowedThirdPartyRoles().contains(user.getRoles());
             }
             default: {
                 return false;
             }
         }
-        return false;
     }
 
 }

--- a/src/main/resources/db/migration/V1.2__pi_user_update_courtel_roles.sql
+++ b/src/main/resources/db/migration/V1.2__pi_user_update_courtel_roles.sql
@@ -1,0 +1,7 @@
+--
+-- Replace the Courtel users' role to the new third party user provenance and role
+--
+UPDATE pi_user
+SET roles = 'GENERAL_THIRD_PARTY',
+    user_provenance = 'THIRD_PARTY'
+WHERE roles = 'TECHNICAL';


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/PUB-1495

### Change description ###

- Add new user provenance and roles for third party users.
- Update sensitivity service to include the new user provenance and types for private and classified lists.
- Add flyway transformation to replace all TECHNICAL user role with the GENERAL_THIRD_PARTY role.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
