### PR TITLE
Force upgrade snakeyaml version for CVE-2022-25857

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -202,6 +202,11 @@ dependencies {
   // Include Flyway for database migrations
   implementation group: 'org.flywaydb', name: 'flyway-core', version: '8.5.13'
 
+  // Force upgrade snakeyaml version for CVE-2022-25857
+  implementation( group: 'org.yaml', name: 'snakeyaml').version {
+    strictly("1.31")
+  }
+
   testImplementation(platform('org.junit:junit-bom:5.8.2'))
   testImplementation group: 'org.springframework.boot', name: 'spring-boot-starter-test'
   testImplementation group: 'org.springframework.security', name: 'spring-security-test'


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://nvd.nist.gov/vuln/detail/CVE-2022-25857

### Change description ###

Force upgrade snakeyaml version for CVE-2022-25857

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```