### PR TITLE
PUB-2575 Add functional test for inactive accounts

### DIFF
--- a/src/functionalTest/java/uk/gov/hmcts/reform/pip/account/management/controllers/InactiveAccountsManagementTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/pip/account/management/controllers/InactiveAccountsManagementTest.java
@@ -13,18 +13,15 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.core.io.ClassPathResource;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import uk.gov.hmcts.reform.pip.account.management.model.AzureAccount;
-import uk.gov.hmcts.reform.pip.account.management.model.MediaApplication;
 import uk.gov.hmcts.reform.pip.account.management.model.PiUser;
 import uk.gov.hmcts.reform.pip.account.management.utils.FunctionalTestBase;
 import uk.gov.hmcts.reform.pip.account.management.utils.OAuthClient;
 import uk.gov.hmcts.reform.pip.model.account.Roles;
 import uk.gov.hmcts.reform.pip.model.account.UserProvenances;
 
-import java.io.IOException;
 import java.time.Clock;
 import java.time.ZonedDateTime;
 import java.util.List;
@@ -44,7 +41,6 @@ import static org.springframework.http.HttpStatus.OK;
 @SuppressWarnings("PMD.TooManyMethods")
 class InactiveAccountsManagementTest extends FunctionalTestBase {
     private static final String TEST_NAME = "E2E Account Management Test Name";
-    private static final String TEST_EMPLOYER = "E2E Account Management Test Employer";
     private static final Integer TEST_EMAIL_RANDOM_NUMBER =
         ThreadLocalRandom.current().nextInt(1000, 9999);
     private static final String TEST_EMAIL_PREFIX = String.format(
@@ -65,10 +61,7 @@ class InactiveAccountsManagementTest extends FunctionalTestBase {
     private static final String TEST_SYSTEM_ADMIN_EMAIL = TEST_SYSTEM_ADMIN_EMAIL_PREFIX + "@justice.gov.uk";
     private static final String FIRST_NAME = "E2E Account Management";
     private static final String SURNAME = "Test Name";
-    private static final String STATUS = "PENDING";
     private static final String LAST_SINGED_IN_DATE = "lastSignedInDate";
-    private static final String MEDIA_APPLICATION_URL = "/application";
-    private static final String MOCK_FILE = "files/test-image.png";
     private static final String BEARER = "Bearer ";
     private static final String ISSUER_ID = "x-issuer-id";
     private static final Clock CL = Clock.systemUTC();
@@ -98,7 +91,7 @@ class InactiveAccountsManagementTest extends FunctionalTestBase {
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
     @BeforeAll
-    public void startUp() throws IOException {
+    public void startUp() {
 
         String requestBody = """
             {
@@ -115,7 +108,6 @@ class InactiveAccountsManagementTest extends FunctionalTestBase {
         issuerId = Map.of(ISSUER_ID, userId);
 
         //ADD MEDIA USER
-        createApplication();
         AzureAccount mediaUserAzureAccount = createAzureAccount(TEST_EMAIL, Roles.VERIFIED);
         mediaUserProvenanceId = mediaUserAzureAccount.getAzureAccountId();
         mediaUserId = createUser(TEST_EMAIL, mediaUserAzureAccount.getAzureAccountId(),
@@ -137,16 +129,6 @@ class InactiveAccountsManagementTest extends FunctionalTestBase {
         doDeleteRequest(TESTING_SUPPORT_ACCOUNT_URL + TEST_ADMIN_EMAIL, headers);
         doDeleteRequest(TESTING_SUPPORT_ACCOUNT_URL + TEST_IDAM_EMAIL, headers);
         doDeleteRequest(TESTING_SUPPORT_ACCOUNT_URL + TEST_SYSTEM_ADMIN_EMAIL, headers);
-    }
-
-    private MediaApplication createApplication() throws IOException {
-        Response response = doPostMultipartForApplication(MEDIA_APPLICATION_URL, headers,
-                                                          new ClassPathResource(MOCK_FILE).getFile(),
-                                                          TEST_NAME, TEST_EMAIL, TEST_EMPLOYER, STATUS);
-
-        assertThat(response.getStatusCode()).isEqualTo(OK.value());
-
-        return response.getBody().as(MediaApplication.class);
     }
 
     private AzureAccount createAzureAccount(String email, Roles role) {

--- a/src/functionalTest/java/uk/gov/hmcts/reform/pip/account/management/controllers/InactiveAccountsManagementTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/pip/account/management/controllers/InactiveAccountsManagementTest.java
@@ -91,7 +91,7 @@ class InactiveAccountsManagementTest extends FunctionalTestBase {
     private static final String NOTIFY_INACTIVE_IDAM_ACCOUNT = ACCOUNT_URL + "/idam/inactive/notify";
     private static final String DELETE_INACTIVE_IDAM_ACCOUNT = ACCOUNT_URL + "/idam/inactive";
     private static final String ADD_SYSTEM_ADMIN_B2C_URL = ACCOUNT_URL + "/add/system-admin";
-    private static final String TESTING_SUPPORT_APPLICATION_URL = "/testing-support/application/";
+    private static final String TESTING_SUPPORT_APPLICATION_URL = "/testing-support/account/";
     private static final String GET_PI_USER_URL = "/account/%s";
     private static final String SYSTEM_ADMIN_SSO_URL = ACCOUNT_URL + "/system-admin";
 

--- a/src/functionalTest/java/uk/gov/hmcts/reform/pip/account/management/controllers/InactiveAccountsManagementTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/pip/account/management/controllers/InactiveAccountsManagementTest.java
@@ -91,7 +91,7 @@ class InactiveAccountsManagementTest extends FunctionalTestBase {
     private static final String NOTIFY_INACTIVE_IDAM_ACCOUNT = ACCOUNT_URL + "/idam/inactive/notify";
     private static final String DELETE_INACTIVE_IDAM_ACCOUNT = ACCOUNT_URL + "/idam/inactive";
     private static final String ADD_SYSTEM_ADMIN_B2C_URL = ACCOUNT_URL + "/add/system-admin";
-    private static final String TESTING_SUPPORT_APPLICATION_URL = "/testing-support/account/";
+    private static final String TESTING_SUPPORT_ACCOUNT_URL = "/testing-support/account/";
     private static final String GET_PI_USER_URL = "/account/%s";
     private static final String SYSTEM_ADMIN_SSO_URL = ACCOUNT_URL + "/system-admin";
 
@@ -133,10 +133,10 @@ class InactiveAccountsManagementTest extends FunctionalTestBase {
 
     @AfterAll
     public void teardown() {
-        doDeleteRequest(TESTING_SUPPORT_APPLICATION_URL + TEST_EMAIL, headers);
-        doDeleteRequest(TESTING_SUPPORT_APPLICATION_URL + TEST_ADMIN_EMAIL, headers);
-        doDeleteRequest(TESTING_SUPPORT_APPLICATION_URL + TEST_IDAM_EMAIL, headers);
-        doDeleteRequest(TESTING_SUPPORT_APPLICATION_URL + TEST_SYSTEM_ADMIN_EMAIL, headers);
+        doDeleteRequest(TESTING_SUPPORT_ACCOUNT_URL + TEST_EMAIL, headers);
+        doDeleteRequest(TESTING_SUPPORT_ACCOUNT_URL + TEST_ADMIN_EMAIL, headers);
+        doDeleteRequest(TESTING_SUPPORT_ACCOUNT_URL + TEST_IDAM_EMAIL, headers);
+        doDeleteRequest(TESTING_SUPPORT_ACCOUNT_URL + TEST_SYSTEM_ADMIN_EMAIL, headers);
     }
 
     private MediaApplication createApplication() throws IOException {

--- a/src/functionalTest/java/uk/gov/hmcts/reform/pip/account/management/controllers/InactiveAccountsManagementTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/pip/account/management/controllers/InactiveAccountsManagementTest.java
@@ -53,8 +53,8 @@ class InactiveAccountsManagementTest extends FunctionalTestBase {
         "pip-am-test-admin-email-%s", TEST_EMAIL_RANDOM_NUMBER);
     private static final String TEST_IDAM_EMAIL_PREFIX = String.format(
         "pip-am-test-idam-email-%s", TEST_EMAIL_RANDOM_NUMBER);
-    private static final String TEST_B2C_SYSTEM_ADMIN_EMAIL_PREFIX = String.format(
-        "pip-am-test-b2c-email-%s", TEST_EMAIL_RANDOM_NUMBER);
+    private static final String TEST_SYSTEM_ADMIN_EMAIL_PREFIX = String.format(
+        "pip-am-test-system-admin-email-%s", TEST_EMAIL_RANDOM_NUMBER);
     private static final String EMAIL_DOMAIN = "%s@justice.gov.uk";
     private static final String TEST_EMAIL =
         String.format(EMAIL_DOMAIN, TEST_EMAIL_PREFIX);
@@ -62,7 +62,7 @@ class InactiveAccountsManagementTest extends FunctionalTestBase {
         String.format(EMAIL_DOMAIN, TEST_ADMIN_EMAIL_PREFIX);
     private static final String TEST_IDAM_EMAIL =
         String.format(EMAIL_DOMAIN, TEST_IDAM_EMAIL_PREFIX);
-    private static final String TEST_B2C_SYSTEM_ADMIN_EMAIL = TEST_B2C_SYSTEM_ADMIN_EMAIL_PREFIX + "@justice.gov.uk";
+    private static final String TEST_SYSTEM_ADMIN_EMAIL = TEST_SYSTEM_ADMIN_EMAIL_PREFIX + "@justice.gov.uk";
     private static final String FIRST_NAME = "E2E Account Management";
     private static final String SURNAME = "Test Name";
     private static final String STATUS = "PENDING";
@@ -105,7 +105,7 @@ class InactiveAccountsManagementTest extends FunctionalTestBase {
                 "email": "%s",
                 "provenanceUserId": "%s"
             }
-            """.formatted(TEST_B2C_SYSTEM_ADMIN_EMAIL, UUID.randomUUID().toString());
+            """.formatted(TEST_SYSTEM_ADMIN_EMAIL, UUID.randomUUID().toString());
 
         OBJECT_MAPPER.findAndRegisterModules();
 
@@ -136,7 +136,7 @@ class InactiveAccountsManagementTest extends FunctionalTestBase {
         doDeleteRequest(TESTING_SUPPORT_APPLICATION_URL + TEST_EMAIL, headers);
         doDeleteRequest(TESTING_SUPPORT_APPLICATION_URL + TEST_ADMIN_EMAIL, headers);
         doDeleteRequest(TESTING_SUPPORT_APPLICATION_URL + TEST_IDAM_EMAIL, headers);
-        doDeleteRequest(TESTING_SUPPORT_APPLICATION_URL + TEST_B2C_SYSTEM_ADMIN_EMAIL, headers);
+        doDeleteRequest(TESTING_SUPPORT_APPLICATION_URL + TEST_SYSTEM_ADMIN_EMAIL, headers);
     }
 
     private MediaApplication createApplication() throws IOException {

--- a/src/functionalTest/java/uk/gov/hmcts/reform/pip/account/management/utils/FunctionalTestBase.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/pip/account/management/utils/FunctionalTestBase.java
@@ -58,6 +58,18 @@ public class FunctionalTestBase {
             .thenReturn();
     }
 
+    protected Response doPostRequest(final String path, final Map<String, String> additionalHeaders,
+                                     final Map<String, String> issuerId, final String body) {
+        return given()
+            .relaxedHTTPSValidation()
+            .headers(getRequestHeaders(additionalHeaders))
+            .headers(getRequestHeaders(issuerId))
+            .body(body)
+            .when()
+            .post(path)
+            .thenReturn();
+    }
+
     protected Response doPostMultipartForApplication(final String path, final Map<String, String> additionalHeaders,
                                       final File file, String name, String email, String employer, String status) {
         return given()


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/PUB-2575

### Change description ###

Add functional test for inactive accounts for both media and admins

**Does this PR introduce a breaking change?** (check one with "x")
[ ] Yes
[x] No